### PR TITLE
WIP: Backfilling

### DIFF
--- a/data/tables.yaml
+++ b/data/tables.yaml
@@ -1,12 +1,16 @@
 ---
 Common:
   CONTENT:
+    rows: 1
+    occurrences: 1
     required:
       - Class
       - Category
       - Level
       - Form
   DATA_GENERATION:
+    rows: 1
+    occurrences: 1
     required:
       - Date
       - Agency
@@ -14,6 +18,8 @@ Common:
     optional:
       - ScientificAuthority
   PLATFORM:
+    rows: 1
+    occurrences: 1
     required:
       - Type
       - ID
@@ -22,16 +28,22 @@ Common:
     optional:
       - GAW_ID
   INSTRUMENT:
+    rows: 1
+    occurrences: 1
     required:
       - Name
       - Model
       - Number
   LOCATION:
+    rows: 1
+    occurrences: 1
     required:
       - Latitude
       - Longitude
       - Height
   TIMESTAMP:
+    rows: 1
+    occurrences: 1+
     required:
       - UTCOffset
       - Date
@@ -43,11 +55,15 @@ Datasets:
       1:
         1:
           DIFFUSE:
+            rows: 1+
+            occurrences: 1+
             required:
               - Time
               - Irradiance
         2:
           GLOBAL:
+            rows: 1+
+            occurrences: 1+
             required:
               - Time
               - Irradiance
@@ -55,6 +71,8 @@ Datasets:
     1.0:
       1:
         OZONE_SUMMARY:
+          rows: 1
+          occurrences: 1+
           required:
             - Altitudes
             - MinAltitude
@@ -65,6 +83,8 @@ Datasets:
             - EndTime
             - PulsesAveraged
         OZONE_PROFILE:
+          rows: 1+
+          occurrences: 1+
           required:
             - Altitude
             - OzoneDensity
@@ -77,6 +97,8 @@ Datasets:
       1:
         1:
           GLOBAL:
+            rows: 1+
+            occurrences: 1
             required:
               - Wavelength
               - S-Irradiance
@@ -84,6 +106,8 @@ Datasets:
               - SZA
         2:
           SIMULTANEOUS:
+            rows: 1+
+            occurrences: 1
             required:
               - Wavelength
               - GLS-Irradiance
@@ -96,6 +120,8 @@ Datasets:
     1.0:
       1:
         FLIGHT_SUMMARY:
+          rows: 1
+          occurrences: 1
           required:
             - IntegratedO3
             - CorrectionCode
@@ -107,6 +133,8 @@ Datasets:
             - Instrument
             - Number
         PROFILE:
+          rows: 1+
+          occurrences: 1
           required:
             - Pressure
             - O3PartialPressure
@@ -119,6 +147,8 @@ Datasets:
             - RelativeHumidity
             - SampleTemperature
         AUXILIARY_DATA:
+          rows: 1
+          occurrences: 0-1
           optional:
             - MeteoSonde
             - ib1
@@ -128,11 +158,15 @@ Datasets:
             - SampleTemperatureType
             - MinutesGroundO3
         PUMP_CORRECTION:
+          rows: 1+
+          occurrences: 0-1
           optional:
             - Pressure
             - Correction
       2:
         FLIGHT_SUMMARY:
+          rows: 1
+          occurrences: 1
           required:
             - IntegratedO3
             - CorrectionCode
@@ -141,6 +175,8 @@ Datasets:
             - BackgroundCorrection
             - SampleTemperatureType
         PROFILE:
+          rows: 1+
+          occurrences: 1
           required:
             - Duration
             - Pressure
@@ -159,10 +195,14 @@ Datasets:
             - Longitude
             - Height
         PUMP_CORRECTION:
+          rows: 1+
+          occurrences: 0-1
           optional:
             - Pressure
             - PumpCorrectionFactor
         PREFLIGHT_SUMMARY:
+          rows: 1
+          occurrences: 0-1
           optional:
             - Ib0
             - ib1
@@ -172,16 +212,22 @@ Datasets:
             - PumpFlowRate
             - OzoneSondeResponseTime
         RADIOSONDE:
+          rows: 1
+          occurrences: 0-1
           optional:
             - Manufacturer
             - Model
             - Number
         INTERFACE_CARD:
+          rows: 1
+          occurrences: 0-1
           optional:
             - Manufacturer
             - Model
             - Number
         SAMPLING_METHOD:
+          rows: 1
+          occurrences: 0-1
           optional:
             - TypeOzoneFreeAir
             - CorrectionWettingFlow
@@ -193,11 +239,15 @@ Datasets:
             - GroundEquipment
             - ProcessingSoftware
         PUMP_SETTINGS:
+          rows: 1
+          occurrences: 0-1
           optional:
             - MotorCurrent
             - HeadPressure
             - VacuumPressure
         OZONE_REFERENCE:
+          rows: 1
+          occurrences: 0-1
           optional:
             - Name
             - Model
@@ -211,6 +261,8 @@ Datasets:
     1.0:
       1:
         VEHICLE:
+          rows: 1
+          occurrences: 1
           required:
             - Type
             - Name
@@ -218,22 +270,30 @@ Datasets:
             - ExperimenterFlightID
             - ParachuteData
         FLIGHT_SUMMARY:
+          rows: 1
+          occurrences: 1
           required:
             - AltitudeResolution
             - MinAltitude
             - MaxAltitude
         OZONE_SUMMARY:
+          rows: 1
+          occurrences: 1
           required:
             - IntegratedRocketO3
             - IntegratedBalloonO3
             - CrossoverAltitude
             - ResidualO3
         AUXILIARY_DATA:
+          rows: 1
+          occurrences: 1
           required:
             - AirDensityDataSource
             - SourceID
             - BalloonOzoneSondeFlightID
         OZONE_PROFILE:
+          rows: 1+
+          occurrences: 1
           required:
             - Altitude
             - OzoneColDensity
@@ -248,6 +308,8 @@ Datasets:
     1.0:
       1:
         DAILY:
+          rows: 1+
+          occurrences: 1
           required:
             - Date
             - WLCode
@@ -261,12 +323,16 @@ Datasets:
             - mMu
             - ColumnSO2
         MONTHLY:
+          rows: 1
+          occurrences: 0-1
           optional:
             - Date
             - ColumnO3
             - StdDevO3
             - Npts
         SAOZ_DATA_V2:
+          rows: 1+
+          occurrences: 0-1
           optional:
             - Date
             - Jday
@@ -282,6 +348,8 @@ Datasets:
     1.0:
       1:
         OBSERVATIONS:
+          rows: 1+
+          occurrences: 1
           required:
             - Time
             - WLCode
@@ -297,6 +365,8 @@ Datasets:
             - TempC
             - F324
         DAILY_SUMMARY:
+          rows: 1
+          occurrences: 1
           required:
             - WLCode
             - ObsCode
@@ -308,6 +378,8 @@ Datasets:
       1:
         1:
           GLOBAL_SUMMARY:
+            rows: 1
+            occurrences: 1+
             required:
               - Time
               - IntACGIH
@@ -324,6 +396,8 @@ Datasets:
               - Err_SO2
               - F324
           GLOBAL:
+            rows: 1+
+            occurrences: 1+
             required:
               - Wavelength
               - S-Irradiance
@@ -332,6 +406,8 @@ Datasets:
               - SZA
         2:
           GLOBAL_SUMMARY_NSF:
+            rows: 1
+            occurrences: 1+
             required:
               - Filename
               - Volume
@@ -343,6 +419,8 @@ Datasets:
               - E320-400
               - UVIndex
           GLOBAL:
+            rows: 1+
+            occurrences: 1
             required:
               - Wavelength
               - S-Irradiance
@@ -352,12 +430,9 @@ Datasets:
   UmkehrN14:
     1.0:
       1:
-        TIMESTAMP_2:
-          required:
-            - UTCOffset
-            - Date
-            - Time
-        "#N14_VALUES":
+        #N14_VALUES:
+          rows: 1+
+          occurrences: 1
           required:
             - Date
             - H
@@ -383,12 +458,9 @@ Datasets:
             - W
     2.0:
       1:
-        TIMESTAMP_2:
-          required:
-            - UTCOffset
-            - Date
-            - Time
         C_PROFILE:
+          rows: 1+
+          occurrences: 1
           required:
             - Date
             - H

--- a/data/tables.yaml
+++ b/data/tables.yaml
@@ -1,350 +1,390 @@
 ---
-Broad-band:
-  1.0:
-    1:
+Common:
+  CONTENT:
+    required:
+      - Class
+      - Category
+      - Level
+      - Form
+  DATA_GENERATION:
+    required:
+      - Date
+      - Agency
+      - Version
+    optional:
+      - ScientificAuthority
+  PLATFORM:
+    required:
+      - Type
+      - ID
+      - Name
+      - Country
+    optional:
+      - GAW_ID
+  INSTRUMENT:
+    required:
+      - Name
+      - Model
+      - Number
+  LOCATION:
+    required:
+      - Latitude
+      - Longitude
+      - Height
+  TIMESTAMP:
+    required:
+      - UTCOffset
+      - Date
+    optional:
+      - Time
+Datasets:
+  Broad-band:
+    1.0:
+      1:
+        1:
+          required:
+            DIFFUSE:
+              - Time
+              - Irradiance
+        2:
+          required:
+            GLOBAL:
+              - Time
+              - Irradiance
+  Lidar:
+    1.0:
       1:
         required:
-          DIFFUSE:
-          - Time
-          - Irradiance
-      2:
-        required:
-          GLOBAL:
-          - Time
-          - Irradiance
-Lidar:
-  1.0:
-    1:
-      required:
-        OZONE_SUMMARY:
-        - Altitudes
-        - MinAltitude
-        - MaxAltitude
-        - StartDate
-        - StartTime
-        - EndDate
-        - EndTime
-        - PulsesAveraged
-        OZONE_PROFILE:
-        - Altitude
-        - OzoneDensity
-        - StandardError
-        - RangeResolution
-        - AirDensity
-        - Temperature
-Multi-band:
-  1.0:
-    1:
+          OZONE_SUMMARY:
+            - Altitudes
+            - MinAltitude
+            - MaxAltitude
+            - StartDate
+            - StartTime
+            - EndDate
+            - EndTime
+            - PulsesAveraged
+          OZONE_PROFILE:
+            - Altitude
+            - OzoneDensity
+            - StandardError
+            - RangeResolution
+            - AirDensity
+            - Temperature
+  Multi-band:
+    1.0:
+      1:
+        1:
+          required:
+            GLOBAL:
+              - Wavelength
+              - S-Irradiance
+              - Time
+              - SZA
+        2:
+          required:
+            SIMULTANEOUS:
+              - Wavelength
+              - GLS-Irradiance
+              - DFS-Irradiance
+              - DRS-Irradiance
+              - Time
+              - Airmass
+               - SZA
+  OzoneSonde:
+    1.0:
       1:
         required:
-          GLOBAL:
-          - Wavelength
-          - S-Irradiance
-          - Time
-          - SZA
+          FLIGHT_SUMMARY:
+            - IntegratedO3
+            - CorrectionCode
+            - SondeTotalO3
+            - CorrectionFactor
+            - TotalO3
+            - WLCode
+            - ObsType
+            - Instrument
+            - Number
+          PROFILE:
+            - Pressure
+            - O3PartialPressure
+            - Temperature
+            - WindSpeed
+            - WindDirection
+            - LevelCode
+            - Duration
+            - GPHeight
+            - RelativeHumidity
+            - SampleTemperature
+        optional:
+          AUXILIARY_DATA:
+            - MeteoSonde
+            - ib1
+            - ib2
+            - PumpRate
+            - BackgroundCorr
+            - SampleTemperatureType
+            - MinutesGroundO3
+          PUMP_CORRECTION:
+            - Pressure
+            - Correction
       2:
         required:
-          SIMULTANEOUS:
-          - Wavelength
-          - GLS-Irradiance
-          - DFS-Irradiance
-          - DRS-Irradiance
-          - Time
-          - Airmass
-          - SZA
-OzoneSonde:
-  1.0:
-    1:
-      required:
-        FLIGHT_SUMMARY:
-        - IntegratedO3
-        - CorrectionCode
-        - SondeTotalO3
-        - CorrectionFactor
-        - TotalO3
-        - WLCode
-        - ObsType
-        - Instrument
-        - Number
-        PROFILE:
-        - Pressure
-        - O3PartialPressure
-        - Temperature
-        - WindSpeed
-        - WindDirection
-        - LevelCode
-        - Duration
-        - GPHeight
-        - RelativeHumidity
-        - SampleTemperature
-      optional:
-        AUXILIARY_DATA:
-        - MeteoSonde
-        - ib1
-        - ib2
-        - PumpRate
-        - BackgroundCorr
-        - SampleTemperatureType
-        - MinutesGroundO3
-        PUMP_CORRECTION:
-        - Pressure
-        - Correction
-    2:
-      required:
-        FLIGHT_SUMMARY:
-        - IntegratedO3
-        - CorrectionCode
-        - SondeTotalO3
-        - NormalizationFactor
-        - BackgroundCorrection
-        - SampleTemperatureType
-        PROFILE:
-        - Duration
-        - Pressure
-        - O3PartialPressure
-        - Temperature
-        - WindSpeed
-        - WindDirection
-        - LevelCode
-        - GPHeight
-        - RelativeHumidity
-        - SampleTemperature
-        - SondeCurrent
-        - PumpMotorCurrent
-        - PumpMotorVoltage
-        - Latitude
-        - Longitude
-        - Height
-      optional:
-        PUMP_CORRECTION:
-        - Pressure
-        - PumpCorrectionFactor
-        PREFLIGHT_SUMMARY:
-        - Ib0
-        - ib1
-        - ib2
-        - SolutionType
-        - SolutionVolume
-        - PumpFlowRate
-        - OzoneSondeResponseTime
-        RADIOSONDE:
-        - Manufacturer
-        - Model
-        - Number
-        INTERFACE_CARD:
-        - Manufacturer
-        - Model
-        - Number
-        SAMPLING_METHOD:
-        - TypeOzoneFreeAir
-        - CorrectionWettingFlow
-        - SurfaceOzone
-        - DurationSurfaceOzoneExposure
-        - LengthBG
-        - WMOTropopausePressure
-        - BurstOzonePressure
-        - GroundEquipment
-        - ProcessingSoftware
-        PUMP_SETTINGS:
-        - MotorCurrent
-        - HeadPressure
-        - VacuumPressure
-        OZONE_REFERENCE:
-        - Name
-        - Model
-        - Number
-        - Version
-        - TotalO3
-        - WLCode
-        - ObsType
-        - UTC_Mean
-RocketSonde:
-  1.0:
-    1:
-      required:
-        VEHICLE:
-        - Type
-        - Name
-        - RocketID
-        - ExperimenterFlightID
-        - ParachuteData
-        FLIGHT_SUMMARY:
-        - AltitudeResolution
-        - MinAltitude
-        - MaxAltitude
-        OZONE_SUMMARY:
-        - IntegratedRocketO3
-        - IntegratedBalloonO3
-        - CrossoverAltitude
-        - ResidualO3
-        AUXILIARY_DATA:
-        - AirDensityDataSource
-        - SourceID
-        - BalloonOzoneSondeFlightID
-        OZONE_PROFILE:
-        - Altitude
-        - OzoneColDensity
-        - OzoneNumDensity
-        - RelativeError
-        - VolMixingRatio
-        - MassMixingRatio
-        - AirPressure
-        - Temperature
-        - AirDensity
-TotalOzone:
-  1.0:
-    1:
-      required:
-        DAILY:
-        - Date
-        - WLCode
-        - ObsCode
-        - ColumnO3
-        - StdDevO3
-        - UTC_Begin
-        - UTC_End
-        - UTC_Mean
-        - nObs
-        - mMu
-        - ColumnSO2
-      optional:
-        MONTHLY:
-        - Date
-        - ColumnO3
-        - StdDevO3
-        - Npts
-        SAOZ_DATA_V2:
-        - Date
-        - Jday
-        - O3sr
-        - O3ss
-        - dO3sr
-        - dO3ss
-        - NO2sr
-        - NO2ss
-        - dNO2sr
-        - dNO2ss
-TotalOzoneObs:
-  1.0:
-    1:
-      required:
-        OBSERVATIONS:
-        - Time
-        - WLCode
-        - ObsCode
-        - Airmass
-        - ColumnO3
-        - StdDevO3
-        - ColumnSO2
-        - StdDevSO2
-        - ZA
-        - NdFilter
-        - TempC
-        - F324
-        DAILY_SUMMARY:
-        - WLCode
-        - ObsCode
-        - nObs
-        - MeanO3
-        - StdDevO3
-Spectral:
-  1.0:
-    1:
+          FLIGHT_SUMMARY:
+            - IntegratedO3
+            - CorrectionCode
+            - SondeTotalO3
+            - NormalizationFactor
+            - BackgroundCorrection
+            - SampleTemperatureType
+          PROFILE:
+            - Duration
+            - Pressure
+            - O3PartialPressure
+            - Temperature
+            - WindSpeed
+            - WindDirection
+            - LevelCode
+            - GPHeight
+            - RelativeHumidity
+            - SampleTemperature
+            - SondeCurrent
+            - PumpMotorCurrent
+            - PumpMotorVoltage
+            - Latitude
+            - Longitude
+            - Height
+        optional:
+          PUMP_CORRECTION:
+            - Pressure
+            - PumpCorrectionFactor
+          PREFLIGHT_SUMMARY:
+            - Ib0
+            - ib1
+            - ib2
+            - SolutionType
+            - SolutionVolume
+            - PumpFlowRate
+            - OzoneSondeResponseTime
+          RADIOSONDE:
+            - Manufacturer
+            - Model
+            - Number
+          INTERFACE_CARD:
+            - Manufacturer
+            - Model
+            - Number
+          SAMPLING_METHOD:
+            - TypeOzoneFreeAir
+            - CorrectionWettingFlow
+            - SurfaceOzone
+            - DurationSurfaceOzoneExposure
+            - LengthBG
+            - WMOTropopausePressure
+            - BurstOzonePressure
+            - GroundEquipment
+            - ProcessingSoftware
+          PUMP_SETTINGS:
+            - MotorCurrent
+            - HeadPressure
+            - VacuumPressure
+          OZONE_REFERENCE:
+            - Name
+            - Model
+            - Number
+            - Version
+            - TotalO3
+            - WLCode
+            - ObsType
+            - UTC_Mean
+  RocketSonde:
+    1.0:
       1:
         required:
-          GLOBAL_SUMMARY:
-          - Time
-          - IntACGIH
-          - IntCIE
-          - ZenAngle
-          - MuValue
-          - AzimAngle
-          - Flag
-          - TempC
-          - O3
-          - Err_O3
-          - SO2
-          - Err_SO2
-          - F324
-          GLOBAL:
-          - Wavelength
-          - S-Irradiance
-          - Time
-          - SZA
-      2:
+          VEHICLE:
+            - Type
+            - Name
+            - RocketID
+            - ExperimenterFlightID
+            - ParachuteData
+          FLIGHT_SUMMARY:
+            - AltitudeResolution
+            - MinAltitude
+            - MaxAltitude
+          OZONE_SUMMARY:
+            - IntegratedRocketO3
+            - IntegratedBalloonO3
+             - CrossoverAltitude
+            - ResidualO3
+          AUXILIARY_DATA:
+            - AirDensityDataSource
+            - SourceID
+            - BalloonOzoneSondeFlightID
+          OZONE_PROFILE:
+            - Altitude
+            - OzoneColDensity
+            - OzoneNumDensity
+            - RelativeError
+            - VolMixingRatio
+            - MassMixingRatio
+            - AirPressure
+            - Temperature
+            - AirDensity
+  TotalOzone:
+    1.0:
+      1:
         required:
-          GLOBAL_SUMMARY_NSF:
-          - Filename
-          - Volume
-          - SZA
-          - Azimuth
-          - Sky_condition
-          - Minimum_useable_wavelength
-          - E290-320
-          - E320-400
-          - UVIndex
-          GLOBAL:
-          - Wavelength
-          - S-Irradiance
-          - Time
-          - SZA
-UmkehrN14:
-  1.0:
-    1:
-      required:
-        TIMESTAMP_2:
-        - UTCOffset
-        - Date
-        - Time
-        "#N14_VALUES":
-        - Date
-        - H
-        - L
-        - W
-        - WLCode
-        - ObsCode
-        - ColumnO3
-        - N600
-        - N650
-        - N700
-        - N740
-        - N750
-        - N770
-        - N800
-        - N830
-        - N840
-        - N850
-        - N865
-        - N880
-        - N890
-        - N900
-  2.0:
-    1:
-      required:
-        TIMESTAMP_2:
-        - UTCOffset
-        - Date
-        - Time
-        C_PROFILE:
-        - Date
-        - H
-        - L
-        - ColumnO3Obs
-        - ColumnO3Retr
-        - Layer10
-        - Layer9
-        - Layer8
-        - Layer7
-        - Layer6
-        - Layer5
-        - Layer4
-        - Layer3
-        - Layer2
-        - Layer1
-        - ITER
-        - SX
-        - SZA_1
-        - nSZA
-        - DFMRS
-        - FEPS
-        - RMSRES
+          DAILY:
+            - Date
+            - WLCode
+            - ObsCode
+            - ColumnO3
+            - StdDevO3
+            - UTC_Begin
+            - UTC_End
+            - UTC_Mean
+            - nObs
+            - mMu
+            - ColumnSO2
+        optional:
+          MONTHLY:
+            - Date
+            - ColumnO3
+            - StdDevO3
+            - Npts
+          SAOZ_DATA_V2:
+            - Date
+            - Jday
+            - O3sr
+            - O3ss
+            - dO3sr
+            - dO3ss
+            - NO2sr
+            - NO2ss
+            - dNO2sr
+            - dNO2ss
+  TotalOzoneObs:
+    1.0:
+      1:
+        required:
+          OBSERVATIONS:
+            - Time
+            - WLCode
+            - ObsCode
+            - Airmass
+            - ColumnO3
+            - StdDevO3
+            - ColumnSO2
+            - StdDevSO2
+            - ZA
+            - NdFilter
+            - TempC
+            - F324
+          DAILY_SUMMARY:
+            - WLCode
+            - ObsCode
+            - nObs
+            - MeanO3
+            - StdDevO3
+  Spectral:
+    1.0:
+      1:
+        1:
+          required:
+            GLOBAL_SUMMARY:
+              - Time
+              - IntACGIH
+              - IntCIE
+              - ZenAngle
+              - MuValue
+              - AzimAngle
+              - Flag
+              - TempC
+              - O3
+              - Err_O3
+              - SO2
+              - Err_SO2
+              - F324
+            GLOBAL:
+              - Wavelength
+              - S-Irradiance
+              - Time
+              - SZA
+        2:
+          required:
+            GLOBAL_SUMMARY_NSF:
+              - Filename
+              - Volume
+              - SZA
+              - Azimuth
+              - Sky_condition
+              - Minimum_useable_wavelength
+              - E290-320
+              - E320-400
+              - UVIndex
+            GLOBAL:
+              - Wavelength
+              - S-Irradiance
+              - Time
+              - SZA
+  UmkehrN14:
+    1.0:
+      1:
+        required:
+          TIMESTAMP_2:
+            - UTCOffset
+            - Date
+            - Time
+          "#N14_VALUES":
+            - Date
+            - H
+            - L
+            - W
+            - WLCode
+            - ObsCode
+            - ColumnO3
+            - N600
+            - N650
+            - N700
+            - N740
+            - N750
+            - N770
+            - N800
+            - N830
+            - N840
+            - N850
+            - N865
+            - N880
+            - N890
+            - N900
+    2.0:
+      1:
+        required:
+          TIMESTAMP_2:
+            - UTCOffset
+            - Date
+            - Time
+          C_PROFILE:
+            - Date
+            - H
+            - L
+            - ColumnO3Obs
+            - ColumnO3Retr
+            - Layer10
+            - Layer9
+            - Layer8
+            - Layer7
+            - Layer6
+            - Layer5
+            - Layer4
+            - Layer3
+            - Layer2
+            - Layer1
+            - ITER
+            - SX
+            - SZA_1
+            - nSZA
+            - DFMRS
+            - FEPS
+            - RMSRES
+...

--- a/data/tables.yaml
+++ b/data/tables.yaml
@@ -42,20 +42,20 @@ Datasets:
     1.0:
       1:
         1:
-          required:
-            DIFFUSE:
+          DIFFUSE:
+            required:
               - Time
               - Irradiance
         2:
-          required:
-            GLOBAL:
+          GLOBAL:
+            required:
               - Time
               - Irradiance
   Lidar:
     1.0:
       1:
-        required:
-          OZONE_SUMMARY:
+        OZONE_SUMMARY:
+          required:
             - Altitudes
             - MinAltitude
             - MaxAltitude
@@ -64,7 +64,8 @@ Datasets:
             - EndDate
             - EndTime
             - PulsesAveraged
-          OZONE_PROFILE:
+        OZONE_PROFILE:
+          required:
             - Altitude
             - OzoneDensity
             - StandardError
@@ -75,27 +76,27 @@ Datasets:
     1.0:
       1:
         1:
-          required:
-            GLOBAL:
+          GLOBAL:
+            required:
               - Wavelength
               - S-Irradiance
               - Time
               - SZA
         2:
-          required:
-            SIMULTANEOUS:
+          SIMULTANEOUS:
+            required:
               - Wavelength
               - GLS-Irradiance
               - DFS-Irradiance
               - DRS-Irradiance
               - Time
               - Airmass
-               - SZA
+              - SZA
   OzoneSonde:
     1.0:
       1:
-        required:
-          FLIGHT_SUMMARY:
+        FLIGHT_SUMMARY:
+          required:
             - IntegratedO3
             - CorrectionCode
             - SondeTotalO3
@@ -105,7 +106,8 @@ Datasets:
             - ObsType
             - Instrument
             - Number
-          PROFILE:
+        PROFILE:
+          required:
             - Pressure
             - O3PartialPressure
             - Temperature
@@ -116,8 +118,8 @@ Datasets:
             - GPHeight
             - RelativeHumidity
             - SampleTemperature
-        optional:
-          AUXILIARY_DATA:
+        AUXILIARY_DATA:
+          optional:
             - MeteoSonde
             - ib1
             - ib2
@@ -125,19 +127,21 @@ Datasets:
             - BackgroundCorr
             - SampleTemperatureType
             - MinutesGroundO3
-          PUMP_CORRECTION:
+        PUMP_CORRECTION:
+          optional:
             - Pressure
             - Correction
       2:
-        required:
-          FLIGHT_SUMMARY:
+        FLIGHT_SUMMARY:
+          required:
             - IntegratedO3
             - CorrectionCode
             - SondeTotalO3
             - NormalizationFactor
             - BackgroundCorrection
             - SampleTemperatureType
-          PROFILE:
+        PROFILE:
+          required:
             - Duration
             - Pressure
             - O3PartialPressure
@@ -154,11 +158,12 @@ Datasets:
             - Latitude
             - Longitude
             - Height
-        optional:
-          PUMP_CORRECTION:
+        PUMP_CORRECTION:
+          optional:
             - Pressure
             - PumpCorrectionFactor
-          PREFLIGHT_SUMMARY:
+        PREFLIGHT_SUMMARY:
+          optional:
             - Ib0
             - ib1
             - ib2
@@ -166,15 +171,18 @@ Datasets:
             - SolutionVolume
             - PumpFlowRate
             - OzoneSondeResponseTime
-          RADIOSONDE:
+        RADIOSONDE:
+          optional:
             - Manufacturer
             - Model
             - Number
-          INTERFACE_CARD:
+        INTERFACE_CARD:
+          optional:
             - Manufacturer
             - Model
             - Number
-          SAMPLING_METHOD:
+        SAMPLING_METHOD:
+          optional:
             - TypeOzoneFreeAir
             - CorrectionWettingFlow
             - SurfaceOzone
@@ -184,11 +192,13 @@ Datasets:
             - BurstOzonePressure
             - GroundEquipment
             - ProcessingSoftware
-          PUMP_SETTINGS:
+        PUMP_SETTINGS:
+          optional:
             - MotorCurrent
             - HeadPressure
             - VacuumPressure
-          OZONE_REFERENCE:
+        OZONE_REFERENCE:
+          optional:
             - Name
             - Model
             - Number
@@ -200,27 +210,31 @@ Datasets:
   RocketSonde:
     1.0:
       1:
-        required:
-          VEHICLE:
+        VEHICLE:
+          required:
             - Type
             - Name
             - RocketID
             - ExperimenterFlightID
             - ParachuteData
-          FLIGHT_SUMMARY:
+        FLIGHT_SUMMARY:
+          required:
             - AltitudeResolution
             - MinAltitude
             - MaxAltitude
-          OZONE_SUMMARY:
+        OZONE_SUMMARY:
+          required:
             - IntegratedRocketO3
             - IntegratedBalloonO3
-             - CrossoverAltitude
+            - CrossoverAltitude
             - ResidualO3
-          AUXILIARY_DATA:
+        AUXILIARY_DATA:
+          required:
             - AirDensityDataSource
             - SourceID
             - BalloonOzoneSondeFlightID
-          OZONE_PROFILE:
+        OZONE_PROFILE:
+          required:
             - Altitude
             - OzoneColDensity
             - OzoneNumDensity
@@ -233,8 +247,8 @@ Datasets:
   TotalOzone:
     1.0:
       1:
-        required:
-          DAILY:
+        DAILY:
+          required:
             - Date
             - WLCode
             - ObsCode
@@ -246,13 +260,14 @@ Datasets:
             - nObs
             - mMu
             - ColumnSO2
-        optional:
-          MONTHLY:
+        MONTHLY:
+          optional:
             - Date
             - ColumnO3
             - StdDevO3
             - Npts
-          SAOZ_DATA_V2:
+        SAOZ_DATA_V2:
+          optional:
             - Date
             - Jday
             - O3sr
@@ -266,8 +281,8 @@ Datasets:
   TotalOzoneObs:
     1.0:
       1:
-        required:
-          OBSERVATIONS:
+        OBSERVATIONS:
+          required:
             - Time
             - WLCode
             - ObsCode
@@ -276,11 +291,13 @@ Datasets:
             - StdDevO3
             - ColumnSO2
             - StdDevSO2
+          optional:
             - ZA
             - NdFilter
             - TempC
             - F324
-          DAILY_SUMMARY:
+        DAILY_SUMMARY:
+          required:
             - WLCode
             - ObsCode
             - nObs
@@ -290,8 +307,8 @@ Datasets:
     1.0:
       1:
         1:
-          required:
-            GLOBAL_SUMMARY:
+          GLOBAL_SUMMARY:
+            required:
               - Time
               - IntACGIH
               - IntCIE
@@ -300,19 +317,22 @@ Datasets:
               - AzimAngle
               - Flag
               - TempC
+            optional:
               - O3
               - Err_O3
               - SO2
               - Err_SO2
               - F324
-            GLOBAL:
+          GLOBAL:
+            required:
               - Wavelength
               - S-Irradiance
               - Time
+            optional:
               - SZA
         2:
-          required:
-            GLOBAL_SUMMARY_NSF:
+          GLOBAL_SUMMARY_NSF:
+            required:
               - Filename
               - Volume
               - SZA
@@ -322,24 +342,26 @@ Datasets:
               - E290-320
               - E320-400
               - UVIndex
-            GLOBAL:
+          GLOBAL:
+            required:
               - Wavelength
               - S-Irradiance
               - Time
+            optional:
               - SZA
   UmkehrN14:
     1.0:
       1:
-        required:
-          TIMESTAMP_2:
+        TIMESTAMP_2:
+          required:
             - UTCOffset
             - Date
             - Time
-          "#N14_VALUES":
+        "#N14_VALUES":
+          required:
             - Date
             - H
             - L
-            - W
             - WLCode
             - ObsCode
             - ColumnO3
@@ -357,14 +379,17 @@ Datasets:
             - N880
             - N890
             - N900
+          optional:
+            - W
     2.0:
       1:
-        required:
-          TIMESTAMP_2:
+        TIMESTAMP_2:
+          required:
             - UTCOffset
             - Date
             - Time
-          C_PROFILE:
+        C_PROFILE:
+          required:
             - Date
             - H
             - L

--- a/data/tables_backfilling.yaml
+++ b/data/tables_backfilling.yaml
@@ -1,0 +1,502 @@
+---
+Common:
+  CONTENT:
+    rows: 1
+    occurrences: 1
+    required:
+      - Class
+      - Category
+      - Level
+      - Form
+  DATA_GENERATION:
+    rows: 1
+    occurrences: 1
+    required:
+      - Date
+      - Agency
+      - Version
+    optional:
+      - ScientificAuthority
+  PLATFORM:
+    rows: 1
+    occurrences: 1
+    required:
+      - Type
+      - ID
+      - Name
+      - Country
+    optional:
+      - GAW_ID
+  INSTRUMENT:
+    rows: 1
+    occurrences: 1
+    required:
+      - Name
+      - Model
+    optional:
+      - Number
+  LOCATION:
+    rows: 1
+    occurrences: 1
+    required:
+      - Latitude
+      - Longitude
+    optional:
+      - Height
+  TIMESTAMP:
+    rows: 1
+    occurrences: 1+
+    required:
+      - UTCOffset
+      - Date
+    optional:
+      - Time
+Datasets:
+  Broad-band:
+    1.0:
+      1:
+        1:
+          DIFFUSE:
+            rows: 1+
+            occurrences: 1+
+            required:
+              - Time
+            optional:
+              - Irradiance
+        2:
+          GLOBAL:
+            rows: 1+
+            occurrences: 1+
+            required:
+              - Time
+            optional:
+              - Irradiance
+  Lidar:
+    1.0:
+      1:
+        OZONE_SUMMARY:
+          rows: 1
+          occurrences: 1+
+          required:
+            - Altitudes
+            - MinAltitude
+            - MaxAltitude
+            - StartDate
+            - StartTime
+          optional:
+            - EndDate
+            - EndTime
+            - PulsesAveraged
+        OZONE_PROFILE:
+          rows: 1+
+          occurrences: 1+
+          required:
+            - Altitude
+            - OzoneDensity
+            - StandardError
+            - RangeResolution
+          optional:
+            - AirDensity
+            - Temperature
+  Multi-band:
+    1.0:
+      1:
+        1:
+          GLOBAL:
+            rows: 1+
+            occurrences: 1
+            required:
+              - Wavelength
+              - S-Irradiance
+              - Time
+            optional:
+              - SZA
+        2:
+          SIMULTANEOUS:
+            rows: 1+
+            occurrences: 1
+            required:
+              - Wavelength
+              - Time
+            optional:
+              - GLS-Irradiance
+              - DFS-Irradiance
+              - DRS-Irradiance
+              - Airmass
+              - SZA
+  OzoneSonde:
+    1.0:
+      1:
+        FLIGHT_SUMMARY:
+          rows: 1
+          occurrences: 1
+          optional:
+            - IntegratedO3
+            - CorrectionCode
+            - SondeTotalO3
+            - CorrectionFactor
+            - TotalO3
+            - WLCode
+            - ObsType
+            - Instrument
+            - Number
+        PROFILE:
+          rows: 1+
+          occurrences: 1
+          optional:
+            - Pressure
+            - O3PartialPressure
+            - Temperature
+            - WindSpeed
+            - WindDirection
+            - LevelCode
+            - Duration
+            - GPHeight
+            - RelativeHumidity
+            - SampleTemperature
+        AUXILIARY_DATA:
+          rows: 1
+          occurrences: 0-1
+          optional:
+            - MeteoSonde
+            - ib1
+            - ib2
+            - PumpRate
+            - BackgroundCorr
+            - SampleTemperatureType
+            - MinutesGroundO3
+        PUMP_CORRECTION:
+          rows: 1+
+          occurrences: 0-1
+          optional:
+            - Pressure
+            - Correction
+      2:
+        FLIGHT_SUMMARY:
+          rows: 1
+          occurrences: 1
+          required:
+            - IntegratedO3
+            - SondeTotalO3
+            - BackgroundCorrection
+            - SampleTemperatureType
+          optional:
+            - CorrectionCode
+            - NormalizationFactor
+
+        PROFILE:
+          rows: 1+
+          occurrences: 1
+          required:
+            - Duration
+            - Pressure
+            - O3PartialPressure
+            - Temperature
+            - WindSpeed
+            - WindDirection
+            - LevelCode
+            - GPHeight
+            - RelativeHumidity
+            - SampleTemperature
+            - SondeCurrent
+            - Latitude
+            - Longitude
+          optional:
+            - PumpMotorCurrent
+            - PumpMotorVoltage
+            - Height
+        PUMP_CORRECTION:
+          rows: 1+
+          occurrences: 0-1
+          optional:
+            - Pressure
+            - PumpCorrectionFactor
+        PREFLIGHT_SUMMARY:
+          rows: 1
+          occurrences: 0-1
+          optional:
+            - Ib0
+            - ib1
+            - ib2
+            - SolutionType
+            - SolutionVolume
+            - PumpFlowRate
+            - OzoneSondeResponseTime
+        RADIOSONDE:
+          rows: 1
+          occurrences: 0-1
+          optional:
+            - Manufacturer
+            - Model
+            - Number
+        INTERFACE_CARD:
+          rows: 1
+          occurrences: 0-1
+          optional:
+            - Manufacturer
+            - Model
+            - Number
+        SAMPLING_METHOD:
+          rows: 1
+          occurrences: 0-1
+          optional:
+            - TypeOzoneFreeAir
+            - CorrectionWettingFlow
+            - SurfaceOzone
+            - DurationSurfaceOzoneExposure
+            - LengthBG
+            - WMOTropopausePressure
+            - BurstOzonePressure
+            - GroundEquipment
+            - ProcessingSoftware
+        PUMP_SETTINGS:
+          rows: 1
+          occurrences: 0-1
+          optional:
+            - MotorCurrent
+            - HeadPressure
+            - VacuumPressure
+        OZONE_REFERENCE:
+          rows: 1
+          occurrences: 0-1
+          optional:
+            - Name
+            - Model
+            - Number
+            - Version
+            - TotalO3
+            - WLCode
+            - ObsType
+            - UTC_Mean
+  RocketSonde:
+    1.0:
+      1:
+        VEHICLE:
+          rows: 1
+          occurrences: 1
+          required:
+            - Type
+            - Name
+            - RocketID
+            - ExperimenterFlightID
+            - ParachuteData
+        FLIGHT_SUMMARY:
+          rows: 1
+          occurrences: 1
+          required:
+            - AltitudeResolution
+            - MinAltitude
+            - MaxAltitude
+        OZONE_SUMMARY:
+          rows: 1
+          occurrences: 1
+          required:
+            - IntegratedRocketO3
+            - IntegratedBalloonO3
+            - CrossoverAltitude
+            - ResidualO3
+        AUXILIARY_DATA:
+          rows: 1
+          occurrences: 1
+          required:
+            - AirDensityDataSource
+            - SourceID
+            - BalloonOzoneSondeFlightID
+        OZONE_PROFILE:
+          rows: 1+
+          occurrences: 1
+          required:
+            - Altitude
+          optional:
+            - OzoneColDensity
+            - OzoneNumDensity
+            - RelativeError
+            - VolMixingRatio
+            - MassMixingRatio
+            - AirPressure
+            - Temperature
+            - AirDensity
+  TotalOzone:
+    1.0:
+      1:
+        DAILY:
+          rows: 1+
+          occurrences: 1
+          required:
+            - Date
+          optional:
+            - WLCode
+            - ObsCode
+            - ColumnO3
+            - StdDevO3
+            - UTC_Begin
+            - UTC_End
+            - UTC_Mean
+            - nObs
+            - mMu
+            - ColumnSO2
+        MONTHLY:
+          rows: 1
+          occurrences: 0-1
+          optional:
+            - Date
+            - ColumnO3
+            - StdDevO3
+            - Npts
+        SAOZ_DATA_V2:
+          rows: 1+
+          occurrences: 0-1
+          optional:
+            - Date
+            - Jday
+            - O3sr
+            - O3ss
+            - dO3sr
+            - dO3ss
+            - NO2sr
+            - NO2ss
+            - dNO2sr
+            - dNO2ss
+  TotalOzoneObs:
+    1.0:
+      1:
+        OBSERVATIONS:
+          rows: 1+
+          occurrences: 1
+          required:
+            - Time
+            - WLCode
+            - ObsCode
+            - Airmass
+            - ColumnO3
+          optional:
+            - StdDevO3
+            - ColumnSO2
+            - StdDevSO2
+            - ZA
+            - NdFilter
+            - TempC
+            - F324
+        DAILY_SUMMARY:
+          rows: 1
+          occurrences: 1
+          required:
+            - WLCode
+            - ObsCode
+            - nObs
+            - MeanO3
+          optional:
+            - StdDevO3
+  Spectral:
+    1.0:
+      1:
+        1:
+          GLOBAL_SUMMARY:
+            rows: 1
+            occurrences: 1+
+            required:
+              - Time
+              - IntACGIH
+            optional:
+              - IntCIE
+              - ZenAngle
+              - MuValue
+              - AzimAngle
+              - Flag
+              - TempC
+              - O3
+              - Err_O3
+              - SO2
+              - Err_SO2
+              - F324
+          GLOBAL:
+            rows: 1+
+            occurrences: 1+
+            required:
+              - Wavelength
+              - S-Irradiance
+            optional:
+              - Time
+              - SZA
+        2:
+          GLOBAL_SUMMARY_NSF:
+            rows: 1
+            occurrences: 1+
+            required:
+              - Filename
+              - Volume
+              - SZA
+              - Azimuth
+              - Minimum_useable_wavelength
+              - E290-320
+              - E320-400
+              - UVIndex
+            optional:
+              - Sky_condition
+          GLOBAL:
+            rows: 1+
+            occurrences: 1
+            required:
+              - Wavelength
+              - S-Irradiance
+              - Time
+            optional:
+              - SZA
+  UmkehrN14:
+    1.0:
+      1:
+        #N14_VALUES:
+          rows: 1+
+          occurrences: 1
+          required:
+            - Date
+            - H
+            - WLCode
+            - ObsCode
+            - ColumnO3
+          optional:
+            - L
+            - W
+            - N600
+            - N650
+            - N700
+            - N740
+            - N750
+            - N770
+            - N800
+            - N830
+            - N840
+            - N850
+            - N865
+            - N880
+            - N890
+            - N900
+    2.0:
+      1:
+        C_PROFILE:
+          rows: 1+
+          occurrences: 1
+          required:
+            - Date
+            - H
+            - L
+            - ColumnO3Obs
+            - ColumnO3Retr
+            - Layer10
+            - Layer9
+            - Layer8
+            - Layer7
+            - Layer6
+            - Layer5
+            - Layer4
+            - Layer3
+            - Layer2
+            - Layer1
+            - ITER
+            - SX
+            - SZA_1
+            - nSZA
+            - DFMRS
+            - FEPS
+            - RMSRES
+...

--- a/data/tables_backfilling.yaml
+++ b/data/tables_backfilling.yaml
@@ -14,8 +14,8 @@ Common:
     required:
       - Date
       - Agency
-      - Version
     optional:
+      - Version
       - ScientificAuthority
   PLATFORM:
     rows: 1

--- a/woudc_data_registry/models.py
+++ b/woudc_data_registry/models.py
@@ -129,6 +129,7 @@ class Contributor(base):
 
     identifier = Column(String, primary_key=True)
     name = Column(String, nullable=False)
+    acronym = Column(String, nullable=False)
     country_id = Column(String, ForeignKey('countries.identifier'),
                         nullable=False)
     project = Column(String, nullable=False, default='WOUDC')
@@ -151,6 +152,7 @@ class Contributor(base):
 
         self.identifier = dict_['identifier']
         self.name = dict_['name']
+        self.acronym = dict_['acronym']
         self.country_id = dict_['country_id']
         self.project = dict_['project']
         self.wmo_region_id = dict_['wmo_region_id']
@@ -368,7 +370,8 @@ class Deployment(base):
             else:
                 self.start_date = datetime.datetime.strptime(
                     dict_['start_date'], '%Y-%m-%d').date()
-            if isinstance(dict_['end_date'], datetime.date):
+            if dict_['end_date'] is None \
+               or isinstance(dict_['end_date'], datetime.date):
                 self.end_date = dict_['end_date']
             else:
                 self.end_date = datetime.datetime.strptime(

--- a/woudc_data_registry/models.py
+++ b/woudc_data_registry/models.py
@@ -657,7 +657,7 @@ def unpack_station_names(rows):
         if name.startswith('\\x'):
             name = decode_hex(name[2:])[0].decode('utf-8')
             row['name'] = name
-            row['identifier'] = ':'.join([row['station_id'], name])
+            row['identifier'] = ':'.join([station, name])
         if name not in tracker:
             tracker[name] = row
         else:

--- a/woudc_data_registry/parser.py
+++ b/woudc_data_registry/parser.py
@@ -317,7 +317,7 @@ class ExtendedCSV(object):
         else:
             noon_indicator = None
 
-        separators = re.findall('[^\w\d]', timestamp)
+        separators = re.findall(r'[^\w\d]', timestamp)
         bad_seps = set(separators) - set(':')
 
         for separator in bad_seps:
@@ -404,7 +404,7 @@ class ExtendedCSV(object):
         :returns: The datestamp converted to a datetime object.
         """
 
-        separators = re.findall('[^\w\d]', datestamp)
+        separators = re.findall(r'[^\w\d]', datestamp)
         bad_seps = set(separators) - set('-')
 
         for separator in bad_seps:
@@ -470,7 +470,7 @@ class ExtendedCSV(object):
     def parse_utcoffset(self, table, utcoffset, line_num):
         """
         Validates the raw string <utcoffset>, converting it to the expected
-        format defined by the regular expression (+|-)\d\d:\d\d:\d\d if
+        format defined by the regular expression (+|-)\\d\\d:\\d\\d:\\d\\d if
         possible. Returns the converted value or else raises a ValueError.
 
         The other parameters are used for error reporting.
@@ -481,7 +481,7 @@ class ExtendedCSV(object):
         :returns: The value converted to expected UTCOffset format.
         """
 
-        separators = re.findall('[^-\+\w\d]', utcoffset)
+        separators = re.findall(r'[^-\+\w\d]', utcoffset)
         bad_seps = set(separators) - set(':')
 
         for separator in bad_seps:
@@ -490,10 +490,10 @@ class ExtendedCSV(object):
             self._warning(1000, line_num, msg)
             utcoffset = utcoffset.replace(separator, ':')
 
-        sign = '(\+|-|\+-)?'
-        delim = '[^-\+\w\d]'
-        mandatory_place = '([\d]{1,2})'
-        optional_place = '(' + delim + '([\d]{0,2}))?'
+        sign = r'(\+|-|\+-)?'
+        delim = r'[^-\+\w\d]'
+        mandatory_place = r'([\d]{1,2})'
+        optional_place = '(' + delim + r'([\d]{0,2}))?'
 
         template = '^{sign}{mandatory}{optional}{optional}$' \
                    .format(sign=sign, mandatory=mandatory_place,
@@ -523,7 +523,7 @@ class ExtendedCSV(object):
             if not second:
                 msg = 'Missing #{}.UTCOffset second, defaulting to 00' \
                       .format(table)
-                self._warning(1000, values_line, msg)
+                self._warning(1000, line_num, msg)
                 second = '00'
             elif len(second) < 2:
                 msg = '#{}.UTCOffset second should be 2 digits long' \
@@ -557,14 +557,14 @@ class ExtendedCSV(object):
 
         if len(match) == 1:
             msg = '{}.UTCOffset is a series of zeroes, correcting to' \
-                  ' +00:00:00'.format(table_name)
-            self._warning(23, values_line, msg)
+                  ' +00:00:00'.format(table)
+            self._warning(23, line_num, msg)
 
             return '+00:00:00'
 
         msg = 'Improperly formatted #{}.UTCOffset {}' \
               .format(table, utcoffset)
-        self._error(24, values_line, msg)
+        self._error(24, line_num, msg)
         raise ValueError(msg)
 
     def gen_woudc_filename(self):
@@ -598,7 +598,6 @@ class ExtendedCSV(object):
                           if table not in self.extcsv.keys()]
         present_tables = [table for table in self.extcsv.keys()
                           if table.rstrip('0123456789_') in DOMAINS['Common']]
-        errors = []
 
         if len(present_tables) == 0:
             msg = 'No core metadata tables found. Not an Extended CSV file'
@@ -621,8 +620,8 @@ class ExtendedCSV(object):
             lower, upper = parse_integer_range(str(schema['occurrences']))
             if count < lower:
                 msg = 'At least {} occurrencess of table #{} are required' \
-                      .format(lower, table)
-                line = self.line_num(table_type + '_' + str(table_count))
+                      .format(lower, table_type)
+                line = self.line_num(table_type + '_' + str(count))
                 self._error(1000, line, msg)
             elif count > upper:
                 msg = 'Cannot have more than {} occurrences of #{}' \
@@ -841,8 +840,8 @@ class ExtendedCSV(object):
                 str(schema[table_type]['occurrences']))
             if table_type in required_tables and count < lower:
                 msg = 'At least {} occurrencess of table #{} are required' \
-                      .format(lower, table)
-                line = self.line_num(table_type + '_' + str(table_count))
+                      .format(lower, table_type)
+                line = self.line_num(table_type + '_' + str(count))
                 self._error(1000, line, msg)
                 success = False
             if count > upper:
@@ -885,7 +884,7 @@ class ExtendedCSV(object):
                     self._warning(1000, fields_line, msg)
 
                     self.extcsv[table][field] = \
-                         self.extcsv[table].pop(match_insensitive)
+                        self.extcsv[table].pop(match_insensitive)
                 else:
                     msg = 'Missing required field {}.{}'.format(table, field)
                     self._error(3, fields_line, msg)
@@ -936,7 +935,7 @@ class ExtendedCSV(object):
                     self._warning(27.5, start_line, msg)
             elif not lower <= num_rows <= upper:
                 msg = 'Incorrectly formatted table: #{}. Table must contain' \
-                      ' {} lines'.format(table, occurrence_range)
+                      ' {} lines'.format(table, table_height_range)
 
             LOGGER.debug('Successfully validated table {}'.format(table))
 

--- a/woudc_data_registry/parser.py
+++ b/woudc_data_registry/parser.py
@@ -152,6 +152,19 @@ class ExtendedCSV(object):
         lines = enumerate(reader, 1)
 
         for line_num, row in lines:
+            separators = []
+            for bad_sep in ['::', ';', '$', '%', '|', '/', '\\']:
+                if len(row) > 0 and bad_sep in row[0]:
+                    separators.append(bad_sep)
+
+            for separator in separators:
+                comma_separated = row[0].replace(separator, ',')
+                row = next(csv.reader(StringIO(comma_separated)))
+
+                msg = 'Improper delimiter used \'{}\', corrected to \',\'' \
+                      ' (comma)'.format(separator)
+                self.warnings.append((7, msg, line_num))
+
             if len(row) == 1 and row[0].startswith('#'):  # table name
                 parent_table = ''.join(row).lstrip('#').rstrip()
 

--- a/woudc_data_registry/parser.py
+++ b/woudc_data_registry/parser.py
@@ -657,6 +657,32 @@ class ExtendedCSV(object):
                     self.warnings.append((4, msg, line))
                     del self.extcsv[table][field]
 
+            num_rows = 0
+            for field in required:
+                column = self.extcsv[table][field]
+                num_rows = len(column)
+
+                for line, value in enumerate(column, values_line):
+                    if not column:
+                        msg = 'Required value #{}.{} is empty'.format(table,
+                                                                      field)
+                        self.errors.append((5, msg, values_line))
+                        break
+
+            occurrence_range = str(definitions['occurrences'])
+            lower, upper = parse_integer_range(occurrence_range)
+            if num_rows == 0:
+                if 'required' in definitions:
+                    msg = 'Required table #{} is empty'.format(table)
+                    self.errors.append((27, msg, start_line))
+                else:
+                    msg = 'Optional table #{} is empty'.format(table)
+                    self.warnings.append((27.5, msg, start_line))
+            elif not lower <= num_rows <= upper:
+                msg = 'Incorrectly formatted table: #{}. Table must contain' \
+                      ' {} lines'.format(table, occurrence_range)
+                self.warnings.append((27, msg, start_line))
+
         for table in present_tables:
             body = self.extcsv[table]
             arbitrary_column, values = next(iter(body.items()))
@@ -842,6 +868,28 @@ class ExtendedCSV(object):
                           .format(field, table)
                     self.warnings.append((4, msg, fields_line))
                     del self.extcsv[table][field]
+
+            for field in required:
+                column = self.extcsv[table][field]
+                for line, value in enumerate(column, values_line):
+                    if not value:
+                        msg = 'Required value #{}.{} is empty' \
+                              .format(table, field)
+                        self.errors.append((5, msg, line))
+                        break
+
+            table_height_range = str(schema[table_type]['rows'])
+            lower, upper = parse_integer_range(table_height_range)
+            if num_rows == 0:
+                if 'required' in schema[table_type]:
+                    msg = 'Required table #{} is empty'.format(table)
+                    self.errors.append((27, msg, start_line))
+                else:
+                    msg = 'Optional table #{} is empty'.format(table)
+                    self.warnings.append((27.5, msg, start_line))
+            elif not lower <= num_rows <= upper:
+                msg = 'Incorrectly formatted table: #{}. Table must contain' \
+                      ' {} lines'.format(table, occurrence_range)
 
             LOGGER.debug('Successfully validated table {}'.format(table))
 

--- a/woudc_data_registry/parser.py
+++ b/woudc_data_registry/parser.py
@@ -175,14 +175,23 @@ class ExtendedCSV(object):
                     self._table_count[parent_table] = updated_count
                     parent_table += '_' + str(updated_count)
 
-                LOGGER.debug('Found new table {}'.format(parent_table))
-                ln, fields = next(lines)
-                while is_empty_line(fields):
-                    msg = 'Unexpected empty line'
-                    self.warnings.append((8, msg, ln))
+                try:
+                    LOGGER.debug('Found new table {}'.format(parent_table))
                     ln, fields = next(lines)
 
-                self.init_table(parent_table, fields, line_num)
+                    while is_empty_line(fields):
+                        msg = 'Unexpected empty line between table name' \
+                              ' and fields'
+                        LOGGER.warning(msg)
+                        self.warnings.append((8, msg, ln))
+
+                        ln, fields = next(lines)
+
+                    self.init_table(parent_table, fields, line_num)
+                except StopIteration:
+                    msg = 'Table {} has no fields'.format(parent_table)
+                    LOGGER.error(msg)
+                    self.errors.append((6, msg, line_num))
             elif len(row) > 0 and row[0].startswith('*'):  # comment
                 LOGGER.debug('Found comment')
                 parent_table = None

--- a/woudc_data_registry/parser.py
+++ b/woudc_data_registry/parser.py
@@ -576,7 +576,7 @@ class ExtendedCSV(object):
 
         return filename
 
-    def validate_metadata(self):
+    def validate_metadata_tables(self):
         """validate core metadata tables and fields"""
 
         missing_tables = [table for table in DOMAINS['Common']
@@ -625,13 +625,12 @@ class ExtendedCSV(object):
                     line = self._line_num[table] + 1
                     self.warnings.append((4, msg, line))
 
-        self.check_dataset()
         if len(self.errors) == 0:
             LOGGER.debug('All tables in file validated.')
         else:
             raise MetadataValidationError('Invalid metadata', self.errors)
 
-    def check_dataset(self):
+    def validate_dataset_tables(self):
         tables = DOMAINS['Datasets']
         curr_dict = tables
         fields_line = self._line_num['CONTENT'] + 1

--- a/woudc_data_registry/parser.py
+++ b/woudc_data_registry/parser.py
@@ -178,6 +178,20 @@ class ExtendedCSV(object):
         if len(self.errors) > 0:
             raise NonStandardDataError(self.errors)
 
+    def line_num(self, table):
+        """
+        Returns the line in the source file at which <table> started.
+        """
+
+        return self._line_num[table]
+
+    def table_count(self, table_type):
+        """
+        Returns the number of tables named <table_type> in the source file.
+        """
+
+        return self._table_count[table_type]
+
     def init_table(self, table_name, fields, line_num):
         """
         Record an empty Extended CSV table named <table_name> with
@@ -586,19 +600,19 @@ class ExtendedCSV(object):
             LOGGER.debug('No missing metadata tables.')
 
         for table_type, schema in DOMAINS['Common'].items():
-            count = self._table_count[table_type]
+            count = self.table_count(table_type)
             schema = DOMAINS['Common'][table_type]
 
             lower, upper = parse_integer_range(str(schema['occurrences']))
             if count < lower:
                 msg = 'At least {} occurrencess of table #{} are required' \
                       .format(lower, table)
-                line = self._line_num[table_type + '_' + str(table_count)]
+                line = self.line_num(table_type + '_' + str(table_count))
                 self.errors.append((1000, msg, line))
             elif count > upper:
                 msg = 'Cannot have more than {} occurrences of #{}' \
                       .format(upper, table_type)
-                line = self.line_num[table_type + '_' + str(upper + 1)]
+                line = self.line_num(table_type + '_' + str(upper + 1))
                 self.errors.append((26, msg, line))
 
         for table, definitions in DOMAINS['Common'].items():
@@ -615,7 +629,7 @@ class ExtendedCSV(object):
             excess_fields = [field for field in provided
                              if field.lower() not in required_case_map]
 
-            start_line = self._line_num[table]
+            start_line = self.line_num(table)
             fields_line = start_line + 1
             values_line = fields_line + 1
 
@@ -653,7 +667,7 @@ class ExtendedCSV(object):
                 else:
                     msg = 'Field name {}.{} is not from approved list' \
                           .format(table, field)
-                    line = self._line_num[table] + 1
+                    line = self.line_num(table) + 1
                     self.warnings.append((4, msg, line))
                     del self.extcsv[table][field]
 
@@ -687,7 +701,7 @@ class ExtendedCSV(object):
             table_type = table.rstrip('0123456789_')
             body = self.extcsv[table]
 
-            start_line = self._line_num[table]
+            start_line = self.line_num(table)
             values_line = start_line + 2
 
             for field, column in body.items():
@@ -707,7 +721,7 @@ class ExtendedCSV(object):
     def validate_dataset_tables(self):
         tables = DOMAINS['Datasets']
         curr_dict = tables
-        fields_line = self._line_num['CONTENT'] + 1
+        fields_line = self.line_num('CONTENT') + 1
 
         for field in ['Category', 'Level', 'Form']:
             key = self.extcsv['CONTENT'][field]
@@ -786,19 +800,19 @@ class ExtendedCSV(object):
         for table_type in schema.keys():
             if table_type not in self._table_count:
                 continue
-            count = self._table_count[table_type]
+            count = self.table_count(table_type)
 
             lower, upper = parse_integer_range(
                 str(schema[table_type]['occurrences']))
             if table_type in required_tables and count < lower:
                 msg = 'At least {} occurrencess of table #{} are required' \
                       .format(lower, table)
-                line = self._line_num[table_type + '_' + str(table_count)]
+                line = self.line_num(table_type + '_' + str(table_count))
                 self.errors.append((1000, msg, line))
             if count > upper:
                 msg = 'Cannot have more than {} occurrences of #{}' \
                       .format(upper, table_type)
-                line = self.line_num[table_type + '_' + str(upper + 1)]
+                line = self.line_num(table_type + '_' + str(upper + 1))
                 self.errors.append((26, msg, line))
 
         for table in present_tables:
@@ -817,7 +831,7 @@ class ExtendedCSV(object):
             extra_fields = [field for field in provided
                             if field.lower() not in required_case_map]
 
-            start_line = self._line_num[table]
+            start_line = self.line_num(table)
             fields_line = start_line + 1
             values_line = fields_line + 1
 
@@ -904,7 +918,7 @@ class ExtendedCSV(object):
             table_type = table.rstrip('0123456789_')
             body = self.extcsv[table]
 
-            start_line = self._line_num[table]
+            start_line = self.line_num(table)
             values_line = start_line + 2
 
             for field, column in body.items():

--- a/woudc_data_registry/parser.py
+++ b/woudc_data_registry/parser.py
@@ -165,8 +165,8 @@ class ExtendedCSV(object):
                 LOGGER.debug('Found new table {}'.format(parent_table))
                 ln, fields = next(lines)
                 while is_empty_line(fields):
-                    msg = 'Unexpected empty line at line {}'.format(ln)
-                    self.warnings.append((8, msg))
+                    msg = 'Unexpected empty line'
+                    self.warnings.append((8, msg, ln))
                     ln, fields = next(lines)
 
                 self.init_table(parent_table, fields, line_num)
@@ -191,7 +191,8 @@ class ExtendedCSV(object):
 
             if len(values) == 0:
                 msg = 'Empty table {}'.format(table)
-                self.warnings.append((140, msg))
+                line = self._line_num[table]
+                self.warnings.append((140, msg, line))
             elif len(values) == 1:
                 for field in body.keys():
                     body[field] = _typecast_value(field, body[field][0])
@@ -239,9 +240,8 @@ class ExtendedCSV(object):
         fillins = len(fields) - len(values)
 
         if fillins < 0:
-            msg = 'Data row at line {} has more values than table columns' \
-                      .format(line_num)
-            self.warnings.append((7, msg))
+            msg = 'Data row has more values than table columns'
+            self.warnings.append((7, msg, line_num))
 
         values.extend([''] * fillins)
         values = values[:len(fields)]
@@ -284,11 +284,11 @@ class ExtendedCSV(object):
 
         if len(present_tables) == 0:
             msg = 'No core metadata tables found. Not an Extended CSV file'
-            self.errors.append((161, msg))
+            self.errors.append((161, msg, None))
         else:
             for missing in missing_tables:
                 msg = 'Missing required table: {}'.format(missing)
-                self.errors.append((1, msg))
+                self.errors.append((1, msg, None))
 
         if self.errors:
             msg = 'Not an Extended CSV file'

--- a/woudc_data_registry/parser.py
+++ b/woudc_data_registry/parser.py
@@ -475,6 +475,24 @@ class ExtendedCSV(object):
         if len(match) == 1:
             sign, hour, _, minute, _, second = match[0]
 
+            if len(hour) < 2:
+                msg = '#{}.UTCOffset hour should be 2 digits long' \
+                      .format(table)
+                self.warnings.append((1000, msg, line_num))
+                hour = hour.rjust(2, '0')
+
+            if len(minute) < 2:
+                msg = '#{}.UTCOffset minute should be 2 digits long' \
+                      .format(table)
+                self.warnings.append((1000, msg, line_num))
+                minute = minute.rjust(2, '0')
+
+            if len(second) < 2:
+                msg = '#{}.UTCOffset second should be 2 digits long' \
+                      .format(table)
+                self.warnings.append((1000, msg, line_num))
+                second = second.rjust(2, '0')
+
             try:
                 magnitude = time(int(hour), int(minute), int(second))
                 return = '{}{}'.format(sign, magnitude)

--- a/woudc_data_registry/parser.py
+++ b/woudc_data_registry/parser.py
@@ -174,21 +174,6 @@ class ExtendedCSV(object):
                 msg = 'Unrecognized data {}'.format(','.join(row))
                 self.errors.append((9, msg, line_num))
 
-        for table, body in self.extcsv.items():
-            arbitrary_column, values = next(iter(body.items()))
-
-            if len(values) == 0:
-                msg = 'Empty table {}'.format(table)
-                line = self._line_num[table]
-                self.warnings.append((140, msg, line))
-            elif len(values) == 1:
-                for field in body.keys():
-                    body[field] = self.typecast_value(field, body[field][0])
-            else:
-                for field in body.keys():
-                    body[field] = list(map(
-                        lambda val: self.typecast_value(field, val), body[field]))
-
         if len(self.errors) > 0:
             raise NonStandardDataError(self.errors)
 
@@ -625,6 +610,29 @@ class ExtendedCSV(object):
                     line = self._line_num[table] + 1
                     self.warnings.append((4, msg, line))
 
+        for table in present_tables:
+            body = self.extcsv[table]
+            arbitrary_column, values = next(iter(body.items()))
+
+            start_line = self._line_num[table]
+            values_line = start_line + 2
+
+            if len(values) == 0:
+                msg = 'Empty table {}'.format(table)
+                line = self._line_num[table]
+                self.warnings.append((140, msg, start_line))
+            elif len(values) == 1:
+                for field in body.keys():
+                    body[field] = self.typecast_value(table, field,
+                                                      body[field][0],
+                                                      values_line)
+            else:
+                for field in body.keys():
+                    body[field] = list(map(
+                        lambda val: self.typecast_value(table, field, val,
+                                                        values_line),
+                        body[field]))
+
         if len(self.errors) == 0:
             LOGGER.debug('All tables in file validated.')
         else:
@@ -758,6 +766,28 @@ class ExtendedCSV(object):
                 LOGGER.warning('Optional table {} is not in file.'.format(
                                table))
 
+        for table in present_tables:
+            body = self.extcsv[table]
+            arbitrary_column, values = next(iter(body.items()))
+
+            start_line = self._line_num[table]
+            values_line = start_line + 2
+
+            if len(values) == 0:
+                msg = 'Empty table {}'.format(table)
+                line = self._line_num[table]
+                self.warnings.append((140, msg, start_line))
+            elif len(values) == 1:
+                for field in body.keys():
+                    body[field] = self.typecast_value(table, field,
+                                                      body[field][0],
+                                                      values_line)
+            else:
+                for field in body.keys():
+                    body[field] = list(map(
+                        lambda val: self.typecast_value(table, field, val,
+                                                        values_line),
+                        body[field]))
 
 class NonStandardDataError(Exception):
     """custom exception handler"""

--- a/woudc_data_registry/parser.py
+++ b/woudc_data_registry/parser.py
@@ -61,8 +61,10 @@ from woudc_data_registry.util import parse_integer_range
 LOGGER = logging.getLogger(__name__)
 
 PROJECT_ROOT = '/home/hurkaa/conda-woudc-data-registry'
-table_definition_file = os.path.join(PROJECT_ROOT, 'data', 'tables.yaml')
-with open(table_definition_file) as table_definitions:
+tables_file = 'tables_backfilling.yaml'
+
+table_definition_path = os.path.join(PROJECT_ROOT, 'data', tables_file)
+with open(table_definition_path) as table_definitions:
     DOMAINS = yaml.safe_load(table_definitions)
 
 ERROR_CODES = {

--- a/woudc_data_registry/parser.py
+++ b/woudc_data_registry/parser.py
@@ -691,7 +691,7 @@ class ExtendedCSV(object):
                 num_rows = len(column)
 
                 for line, value in enumerate(column, values_line):
-                    if not column:
+                    if not value:
                         msg = 'Required value #{}.{} is empty'.format(table,
                                                                       field)
                         self._error(5, values_line, msg)

--- a/woudc_data_registry/parser.py
+++ b/woudc_data_registry/parser.py
@@ -388,6 +388,22 @@ class ExtendedCSV(object):
         :returns: The datestamp converted to a datetime object.
         """
 
+        separators = re.findall('[^\w\d]', datestamp)
+        bad_seps = set(separators) - set('-')
+
+        for separator in bad_seps:
+            msg = '#{}.Date separator \'{}\' corrected to \'-\' (hyphen)' \
+                  .format(table, separator)
+            self.warnings.append((17, msg, line_num))
+
+            datestamp = datestamp.replace(separator, '-')
+
+        if '-' not in datestamp:
+            msg = '#{}.Date missing separator. Proper date format is' \
+                  ' YYYY-MM-DD'.format(table)
+            self.errors.append((18, msg, line_num))
+            raise ValueError(msg)
+
         tokens = datestamp.split('-')
         if len(tokens) < 3:
             msg = '#{}.Date incomplete'.format(table)

--- a/woudc_data_registry/processing.py
+++ b/woudc_data_registry/processing.py
@@ -45,13 +45,12 @@
 
 
 import os
-import re
 import yaml
 
 import shutil
 import logging
 
-from datetime import datetime, time
+from datetime import datetime
 
 from woudc_data_registry import config, registry, search
 from woudc_data_registry.models import (Contributor, DataRecord, Dataset,
@@ -60,7 +59,7 @@ from woudc_data_registry.models import (Contributor, DataRecord, Dataset,
 from woudc_data_registry.parser import (PROJECT_ROOT, DOMAINS, ExtendedCSV,
                                         MetadataValidationError,
                                         NonStandardDataError)
-from woudc_data_registry.util import is_text_file, read_file
+from woudc_data_registry.util import read_file
 
 LOGGER = logging.getLogger(__name__)
 
@@ -230,7 +229,7 @@ class Process(object):
                 LOGGER.warning(msg)
 
                 msg = 'No deployment {} found in registry' \
-                       .format(deployment_id)
+                    .format(deployment_id)
                 line = self.extcsv.line_num('PLATFORM') + 2
                 self._error(65, line, msg)
 
@@ -243,7 +242,7 @@ class Process(object):
             new_serial = old_serial.lstrip('0') or '0'
 
             if old_serial != new_serial:
-                LOGGER.debug('Attempting to search instrument serial number' \
+                LOGGER.debug('Attempting to search instrument serial number'
                              ' {}'.format(new_serial))
 
                 self.extcsv.extcsv['INSTRUMENT']['Number'] = new_serial
@@ -261,7 +260,8 @@ class Process(object):
                 msg = 'New instrument serial number added'
                 self._warning(201, None, msg)
 
-        instrument_args = [self.extcsv.extcsv['INSTRUMENT']['Name'],
+        instrument_args = [
+            self.extcsv.extcsv['INSTRUMENT']['Name'],
             self.extcsv.extcsv['INSTRUMENT']['Model'],
             str(self.extcsv.extcsv['INSTRUMENT']['Number']),
             str(self.extcsv.extcsv['PLATFORM']['ID']),
@@ -593,7 +593,7 @@ class Process(object):
         pl_type = self.extcsv.extcsv['PLATFORM']['Type']
         name = self.extcsv.extcsv['PLATFORM']['Name']
         country = self.extcsv.extcsv['PLATFORM']['Country']
-        gaw_id = str(self.extcsv.extcsv['PLATFORM'].get('GAW_ID', '')) or None
+        # gaw_id = self.extcsv.extcsv['PLATFORM'].get('GAW_ID', None)
 
         # TODO: consider adding and checking #PLATFORM_Type
         LOGGER.debug('Validating station {}:{}'.format(identifier, name))
@@ -652,7 +652,7 @@ class Process(object):
             self.extcsv.extcsv['PLATFORM']['Name'] = name = response.name
             LOGGER.debug('Validated with name {} for id {}'.format(
                 name, identifier))
-        elif add_station_name():
+        elif self.add_station_name():
             LOGGER.info('Added new station name {}'.format(station['name']))
             name_ok = True
         else:
@@ -805,9 +805,10 @@ class Process(object):
         try:
             lon_numeric = float(lon)
             if -180 <= lon_numeric <= 180:
-               LOGGER.debug('Validated instrument longitude')
+                LOGGER.debug('Validated instrument longitude')
             else:
-                msg = '#LOCATION.Longitude is not within the range [-180]-[180]'
+                msg = '#LOCATION.Longitude is not within' \
+                      ' allowable range [-180]-[180]'
                 self._warning(76, values_line, msg)
             lon_ok = True
         except ValueError:
@@ -824,12 +825,10 @@ class Process(object):
             else:
                 msg = '#LOCATION.Height is not within the range [-50]-[5100]'
                 self._warning(76, values_line, msg)
-            height_ok = True
         except ValueError:
             msg = '#LOCATION.Height contains invalid characters'
             self._warning(75, values_line, msg)
             height_numeric = None
-            height_ok = False
 
         station_type = self.extcsv.extcsv['PLATFORM'].get('Type', 'STN')
         if not all([lat_ok, lon_ok]):
@@ -858,7 +857,6 @@ class Process(object):
                 self._error(77, values_line, msg)
             if height_numeric is not None and instrument.z is not None \
                and abs(height_numeric - instrument.z) >= 1:
-                height_ok = False
                 msg = '#LOCATION.Height in file does not match database'
                 self._warning(77, values_line, msg)
 
@@ -953,10 +951,12 @@ class Process(object):
             numeric_version = float(version)
 
             if not 0 <= numeric_version <= 20:
-                msg = '#DATA_GENERATION.Version is not within range [0.0]-[20.0]'
+                msg = '#DATA_GENERATION.Version is not within' \
+                      ' allowable range [0.0]-[20.0]'
                 self._warning(66, values_line, msg)
             if str(version) == str(int(numeric_version)):
-                self.extcsv.extcsv['DATA_GENERATION']['Version'] = numeric_version
+                self.extcsv.extcsv['DATA_GENERATION']['Version'] = \
+                    numeric_version
 
                 msg = '#DATA_GENERATION.Version corrected to one decimal place'
                 self._warning(67, values_line, msg)

--- a/woudc_data_registry/processing.py
+++ b/woudc_data_registry/processing.py
@@ -113,10 +113,9 @@ class Process(object):
             LOGGER.error('Unknown file: {}'.format(err))
             return False
 
-        LOGGER.info('Parsing data record')
-        ecsv = ExtendedCSV(data)
-
         try:
+            LOGGER.info('Parsing data record')
+            ecsv = ExtendedCSV(data)
             LOGGER.info('Validating Extended CSV')
             ecsv.validate_metadata()
             LOGGER.info('Valid Extended CSV')
@@ -283,7 +282,7 @@ class Process(object):
 
         instrument_found = False
         base_serial = self.data_record.instrument_number
-        for serial in [base_serial, base_serial.lstrip('0')]:
+        for serial in list({base_serial, base_serial.lstrip('0')}):
             instrument['serial'] = serial
             result = self.registry.query_multiple_fields(Instrument, instrument,
                                                          fields, case_insensitive)

--- a/woudc_data_registry/processing.py
+++ b/woudc_data_registry/processing.py
@@ -204,7 +204,7 @@ class Process(object):
 
                 msg = 'No deployment {} found in registry' \
                        .format(deployment_id)
-                line = self.extcsv.line_num['PLATFORM'] + 2
+                line = self.extcsv.line_num('PLATFORM') + 2
                 self.errors.append((65, msg, line))
 
         LOGGER.debug('Validating instrument')
@@ -230,7 +230,7 @@ class Process(object):
                 self.warnings.append((201, msg, None))
             else:
                 msg = 'Failed to validate instrument against registry'
-                line = self.extcsv.line_num['INSTRUMENT'] + 2
+                line = self.extcsv.line_num('INSTRUMENT') + 2
                 self.errors.append((139, msg, line))
 
         instrument_args = [self.extcsv.extcsv['INSTRUMENT']['Name'],
@@ -367,7 +367,7 @@ class Process(object):
         if not project:
             self.extcsv.extcsv['CONTENT']['Class'] = project = 'WOUDC'
             msg = 'Missing #CONTENT.Class: default to "WOUDC"'
-            line = self.extcsv.line_num['CONTENT'] + 2
+            line = self.extcsv.line_num('CONTENT') + 2
             self.warnings.append((52, msg, line))
 
         if project in self.projects:
@@ -375,7 +375,7 @@ class Process(object):
             return True
         else:
             msg = 'Project {} not found in registry'.format(project)
-            line = self.extcsv.line_num['CONTENT'] + 2
+            line = self.extcsv.line_num('CONTENT') + 2
 
             self.errors.append((53, msg, line))
             return False
@@ -391,7 +391,7 @@ class Process(object):
             return True
         else:
             msg = 'Dataset {} not found in registry'.format(dataset)
-            line = self.extcsv.line_num['CONTENT'] + 2
+            line = self.extcsv.line_num('CONTENT') + 2
 
             self.errors.append((56, msg, line))
             return False
@@ -420,7 +420,7 @@ class Process(object):
         else:
             msg = 'Contributor {} not found in registry' \
                   .format(contributor['identifier'])
-            line = self.extcsv.line_num['DATA_GENERATION'] + 2
+            line = self.extcsv.line_num('DATA_GENERATION') + 2
 
             self.errors.append((127, msg, line))
             return False
@@ -440,7 +440,7 @@ class Process(object):
 
             msg = 'Ship #PLATFORM.Country = *IW corrected to Country = XY' \
                   ' to meet ISO-3166 standards'
-            line = self.extcsv.line_num['PLATFORM'] + 2
+            line = self.extcsv.line_num('PLATFORM') + 2
             self.warnings.append((105, msg, line))
 
         station = {
@@ -451,7 +451,7 @@ class Process(object):
         }
 
         LOGGER.debug('Validating station id...')
-        values_line = self.extcsv.line_num['PLATFORM'] + 2
+        values_line = self.extcsv.line_num('PLATFORM') + 2
         result = self.registry.query_by_field(Station, 'identifier',
                                               identifier)
         if result:
@@ -540,7 +540,7 @@ class Process(object):
         if not model or model.lower() in ['na', 'n/a']:
             self.extcsv.extcsv['INSTRUMENT']['Model'] = model = 'UNKNOWN'
 
-        values_line = self.extcsv.line_num['INSTRUMENT'] + 2
+        values_line = self.extcsv.line_num('INSTRUMENT') + 2
         if name == 'UNKNOWN':
             msg = '#INSTRUMENT.Name must not be null'
             self.errors.append((72, msg, values_line))
@@ -576,7 +576,7 @@ class Process(object):
         lat = self.extcsv.extcsv['LOCATION']['Latitude']
         lon = self.extcsv.extcsv['LOCATION']['Longitude']
         height = self.extcsv.extcsv['LOCATION'].get('Height', None)
-        values_line = self.extcsv.line_num['LOCATION'] + 2
+        values_line = self.extcsv.line_num('LOCATION') + 2
 
         try:
             lat_numeric = float(lat)
@@ -656,7 +656,7 @@ class Process(object):
 
         level_ok = True
         form_ok = True
-        values_line = self.extcsv.line_num['CONTENT'] + 2
+        values_line = self.extcsv.line_num('CONTENT') + 2
 
         if not level:
             if dataset == 'UmkehrN14' and 'C_PROFILE' in self.extcsv.extcsv:
@@ -709,7 +709,7 @@ class Process(object):
         agency = self.extcsv.extcsv['DATA_GENERATION'].get('Agency', None)
         version = self.extcsv.extcsv['DATA_GENERATION'].get('Version', None)
 
-        values_line = self.extcsv.line_num['DATA_GENERATION']
+        values_line = self.extcsv.line_num('DATA_GENERATION')
 
         if not date:
             msg = 'Missing #DATA_GENERATION.Date, resolved to processing date'

--- a/woudc_data_registry/processing.py
+++ b/woudc_data_registry/processing.py
@@ -578,15 +578,20 @@ class Process(object):
 
     def check_instrument(self):
         name = self.extcsv.extcsv['INSTRUMENT']['Name']
-        model = str(self.extcsv.extcsv['INSTRUMENT']['Model'])
-        serial = str(self.extcsv.extcsv['INSTRUMENT']['Number'])
+        model = self.extcsv.extcsv['INSTRUMENT']['Model']
+        serial = self.extcsv.extcsv['INSTRUMENT']['Number']
         station = str(self.extcsv.extcsv['PLATFORM']['ID'])
         dataset = self.extcsv.extcsv['CONTENT']['Category']
 
         if not name or name.lower() in ['na', 'n/a']:
             self.extcsv.extcsv['INSTRUMENT']['Name'] = name = 'UNKNOWN'
-        if not model or model.lower() in ['na', 'n/a']:
-            self.extcsv.extcsv['INSTRUMENT']['Model'] = model = 'UNKNOWN'
+        if not model or str(model).lower() in ['na', 'n/a']:
+            self.extcsv.extcsv['INSTRUMENT']['Model'] = model = 'na'
+        if not serial or str(serial).lower() in ['na', 'n/a']:
+            self.extcsv.extcsv['INSTRUMENT']['Number'] = serial = 'na'
+
+        model = str(model)
+        serial = str(serial)
 
         values_line = self.extcsv.line_num('INSTRUMENT') + 2
         if name == 'UNKNOWN':

--- a/woudc_data_registry/processing.py
+++ b/woudc_data_registry/processing.py
@@ -844,13 +844,14 @@ class Process(object):
 
             instrument = result[0]
             if lat_numeric is not None and instrument.y is not None \
-               and abs(lat_numeric - instrument.y) >= 1:
+               and abs(lat_numeric - instrument.y) >= 1.5:
                 lat_ok = False
                 msg = '#LOCATION.Latitude in file does not match database'
                 LOGGER.error(msg)
                 self._error(77, values_line, msg)
             if lon_numeric is not None and instrument.x is not None \
-               and abs(lon_numeric - instrument.x) >= 1:
+               and (lat_numeric is None or abs(lat_numeric) < 89.5) \
+               and abs(lon_numeric - instrument.x) >= 1.5:
                 lon_ok = False
                 msg = '#LOCATION.Longitude in file does not match database'
                 LOGGER.error(msg)
@@ -935,6 +936,7 @@ class Process(object):
 
         date = self.extcsv.extcsv['DATA_GENERATION'].get('Date', None)
         version = self.extcsv.extcsv['DATA_GENERATION'].get('Version', None)
+        version = version or 1.0
 
         values_line = self.extcsv.line_num('DATA_GENERATION')
 

--- a/woudc_data_registry/processing.py
+++ b/woudc_data_registry/processing.py
@@ -86,13 +86,15 @@ class Process(object):
         self.process_end = None
         self.registry = registry.Registry()
 
-    def process_data(self, infile, verify_only=False, bypass=False):
+    def process_data(self, infile, core_only=False,
+                     verify_only=False, bypass=False):
         """
-        process incoming data record
+        Process incoming data record.
 
-        :param infile: incoming filepath
-        :param verify_only: perform verification only (no ingest)
-        :param bypass: skip permission prompts
+        :param infile: Path to incoming data file.
+        :param core_only: Whether to only verify core metadata tables.
+        :param verify_only: Whether to perform verification only (not ingest).
+        :param bypass: Whether to skip permission prompts to add records.
 
         :returns: `bool` of processing result
         """
@@ -129,7 +131,8 @@ class Process(object):
             self.extcsv = ExtendedCSV(data)
             LOGGER.info('Validating Extended CSV')
             self.extcsv.validate_metadata_tables()
-            self.extcsv.validate_dataset_tables()
+            if not core_only:
+                self.extcsv.validate_dataset_tables()
             LOGGER.info('Valid Extended CSV')
         except NonStandardDataError as err:
             self.status = 'failed'
@@ -248,6 +251,10 @@ class Process(object):
                     platform_ok, deployment_ok, instrument_ok,
                     location_ok, content_ok, data_generation_ok]):
             return False
+
+        if core_only:
+            msg = 'Core mode detected. NOT validating dataset-specific tables'
+            LOGGER.info(msg)
 
         LOGGER.info('Validating data record')
         self.data_record = DataRecord(self.extcsv)

--- a/woudc_data_registry/registry.py
+++ b/woudc_data_registry/registry.py
@@ -98,7 +98,7 @@ class Registry(object):
             if case_insensitive \
             else field == value
 
-        return self.session.query(obj).filter(field == value).all()
+        return self.session.query(obj).filter(condition).all()
 
     def query_multiple_fields(self, table, values, fields=None,
                               case_insensitive=()):

--- a/woudc_data_registry/registry.py
+++ b/woudc_data_registry/registry.py
@@ -80,20 +80,18 @@ class Registry(object):
 
         return values
 
-    def query_by_field(self, obj, obj_instance, by, case_insensitive=False):
+    def query_by_field(self, obj, by, value, case_insensitive=False):
         """
         query data by field
 
-        :param obj: object (field) to be queried
-        :param obj_instance: object instance to be queried
-        :param by: value to be queried
+        :param obj: Class of table to query in
+        :param by: Field name to be queried
+        :param value: Value of the field in any query results
         :param case_insensitive: Whether to query strings case-insensitively
-
-        :returns: query results
+        :returns: Query results
         """
 
         field = getattr(obj, by)
-        value = getattr(obj_instance, by)
 
         LOGGER.debug('Querying for {}={}'.format(field, value))
         condition = func.lower(field) == value.lower() \
@@ -146,7 +144,9 @@ class Registry(object):
                 self.session.add(obj)
                 # self.session.merge(obj)
             self.session.commit()
-            self.session.close()
         except DataError as err:
             LOGGER.error('Failed to save to registry: {}'.format(err))
             self.session.rollback()
+
+    def close_session(self):
+        self.session.close()

--- a/woudc_data_registry/util.py
+++ b/woudc_data_registry/util.py
@@ -121,6 +121,27 @@ def str2bool(value):
     return value2
 
 
+def parse_integer_range(bounds_string):
+    """
+    Returns an integer lower bound and upper bound of the range defined within
+    <bounds_string>. Formats accepted include 'n', 'n+', and 'm-n'.
+
+    :param bounds_string: String representing a range of integers
+    :return: Pair of integer lower bound and upper bound on the range
+    """
+
+    if bounds_string.endswith('+'):
+        lower_bound = int(bounds_string[:-1])
+        upper_bound = float('inf')
+    elif bounds_string.count('-') == 1:
+        lower_bound, upper_bound = map(int, bounds_string.split('-'))
+    else:
+        lower_bound = int(bounds_string)
+        upper_bound = lower_bound
+
+    return (lower_bound, upper_bound)
+
+
 def is_text_file(file_):
     """
     detect if file is of type text


### PR DESCRIPTION
Expanded on parsing and validation checks to allow (almost) all past files in WOUDC to be processed into the data registry.

Major changes:
  * Added 'loose' validation mode, which does not fail if a file has errors outside of core tables.
  * Introduced all parsing and processing checks (on core tables) made by BPS.
  * Reduced the tighness of various checks (e.g. allow table and field names to be wrongly capitalized, allow UTCOffset sign, minute, and second to be omitted, ...)
  * Greatly increased the number of error recovery stages.
  * Add a few manual, user-input based recovery checks.
  * Modularized processing steps.
  * Adjusted database models and added table to handle station names.

This version of the data registry fails to process some files, either because they are irrecoverable or the fixes should be consulted about. Logs documenting the reasons for all failures (and proposed fixes/actions) are in **/apps/data/woudc-data-registry-logs/backfill-2019-10-25**. Files named *_fails document irrecoverable files, and those named *_fixes document recoverable files and how they can be fixed.