### PR TITLE
Improve Docstring Styles

### DIFF
--- a/woudc_data_registry/controller.py
+++ b/woudc_data_registry/controller.py
@@ -60,10 +60,12 @@ def orchestrate(file_, directory, metadata_only=False,
 
     :param file_: File to process.
     :param directory: Directory to process (recursive).
-    :param metadata_only: Whether to verify only the common metadata tables.
-    :param verify_only: Whether to verify the file for correctness without
-                        processing.
-    :param bypass: Whether to skip permission prompts for adding new records.
+    :param metadata_only: `bool` of whether to verify only the
+                          common metadata tables.
+    :param verify_only: `bool` of whether to verify the file for correctness
+                        without processing.
+    :param bypass: `bool` of whether to skip permission prompts for adding
+                   new records.
     :returns: void
     """
 

--- a/woudc_data_registry/controller.py
+++ b/woudc_data_registry/controller.py
@@ -64,6 +64,7 @@ def orchestrate(file_, directory, metadata_only=False,
     :param verify_only: Whether to verify the file for correctness without
                         processing.
     :param bypass: Whether to skip permission prompts for adding new records.
+    :returns: void
     """
 
     files_to_process = []

--- a/woudc_data_registry/dataset_validators.py
+++ b/woudc_data_registry/dataset_validators.py
@@ -54,6 +54,11 @@ class DatasetValidator(object):
         """
         Record <message> as an error with code <error_code> that took place
         at line <line> in the input file.
+
+        :param error_code: Numeric error code from the error definition files.
+        :param line: Line number in the input file where the error was found.
+        :param message: String message describing the error.
+        :returns: void
         """
 
         LOGGER.warning(message)
@@ -63,6 +68,11 @@ class DatasetValidator(object):
         """
         Record <message> as an error with code <error_code> that took place
         at line <line> in the input file.
+
+        :param error_code: Numeric error code from the error definition files.
+        :param line: Line number in the input file where the error was found.
+        :param message: String message describing the error.
+        :returns: void
         """
 
         LOGGER.error(message)

--- a/woudc_data_registry/dataset_validators.py
+++ b/woudc_data_registry/dataset_validators.py
@@ -84,7 +84,8 @@ class DatasetValidator(object):
         Returns True iff no errors were encountered.
 
         :param extcsv: A parsed Extended CSV file of the appropriate dataset.
-        :returns: True iff the file's dataset-specific tables are error-free.
+        :returns: `bool` of whether the file's dataset-specific tables
+                  are error-free.
         """
 
         return True
@@ -108,7 +109,8 @@ class TotalOzoneValidator(DatasetValidator):
         inconsistencies between #MONTHLY and the data it is derived from.
 
         :param extcsv: A parsed Extended CSV file of TotalOzone data.
-        :returns: True iff the file's dataset-specific tables are error-free.
+        :returns: `bool` of whether the file's dataset-specific tables
+                  are error-free.
         """
 
         LOGGER.info('Beginning TotalOzone-specific checks')
@@ -126,7 +128,7 @@ class TotalOzoneValidator(DatasetValidator):
         Returns True iff no errors were found.
 
         :param extcsv: A parsed Extended CSV file of TotalOzone data.
-        :returns: True iff the ordering of #DAILY Dates is error-free.
+        :returns: `bool` of whether the ordering of #DAILY Dates is error-free.
         """
 
         LOGGER.debug('Assessing order of #DAILY.Date column')
@@ -192,7 +194,7 @@ class TotalOzoneValidator(DatasetValidator):
         and inconsistencies. Returns True iff no errors were found.
 
         :param extcsv: A parsed Extended CSV file of TotalOzone data.
-        :returns: True iff the two #TIMESTAMP tables are error-free.
+        :returns: `bool` of whether the two #TIMESTAMP tables are error-free.
         """
 
         LOGGER.debug('Assessing #TIMESTAMP tables for similarity')
@@ -262,7 +264,7 @@ class TotalOzoneValidator(DatasetValidator):
         comparison with #DAILY. Returns True iff no errors were found.
 
         :param extcsv: A parsed Extended CSV file of TotalOzone data.
-        :returns: True iff the #MONTHLY table is error-free.
+        :returns: `bool` of whether the #MONTHLY table is error-free.
         """
 
         LOGGER.debug('Assessing correctness of #MONTHLY table')
@@ -357,7 +359,8 @@ class TotalOzoneObsValidator(DatasetValidator):
         #OBSERVATIONS tables.
 
         :param extcsv: A parsed Extended CSV file of TotalOzoneObs data.
-        :returns: True iff the file's dataset-specific tables are error-free.
+        :returns: `bool` of whether the file's dataset-specific tables
+                  are error-free.
         """
 
         LOGGER.info('Beginning TotalOzoneObs-specific checks')
@@ -373,7 +376,8 @@ class TotalOzoneObsValidator(DatasetValidator):
         Returns True iff no errors were found.
 
         :param extcsv: A parsed Extended CSV file of TotalOzoneObs data.
-        :returns: True iff the ordering of #OBSERVATIONS.Times is error-free.
+        :returns: `bool` of whether the ordering of #OBSERVATIONS.Times
+                  is error-free.
         """
 
         observations = zip(*extcsv.extcsv['OBSERVATIONS'].values())
@@ -441,7 +445,8 @@ class SpectralValidator(DatasetValidator):
         and #GLOBAL_SUMMARY tables such that the counts of each are different.
 
         :param extcsv: A parsed Extended CSV file of Spectral data.
-        :returns: True iff the file's dataset-specific tables are error-free.
+        :returns: `bool` of whether the file's dataset-specific tables
+                  are error-free.
         """
 
         LOGGER.info('Beginning Spectral-specific checks')
@@ -457,7 +462,7 @@ class SpectralValidator(DatasetValidator):
         in the input file <extcsv>. Returns True iff no errors were found.
 
         :param extcsv: A parsed Extended CSV file of Spectral data.
-        :returns: True iff the file is free of table grouping errors.
+        :returns: `bool` of whether the file is free of table grouping errors.
         """
 
         LOGGER.debug('Assessing #TIMESTAMP, #GLOBAL, #GLOBAL_SUMMARY'
@@ -498,7 +503,8 @@ class LidarValidator(DatasetValidator):
         and #OZONE_SUMMARY tables such that the counts of each are different.
 
         :param extcsv: A parsed Extended CSV file of Lidar data.
-        :returns: True iff the file's dataset-specific tables are error-free.
+        :returns: `bool` of whether the file's dataset-specific tables
+                  are error-free.
         """
 
         LOGGER.info('Beginning Lidar-specific checks')
@@ -514,7 +520,7 @@ class LidarValidator(DatasetValidator):
         in the input file <extcsv>. Returns True iff no errors were found.
 
         :param extcsv: A parsed Extended CSV file of Lidar data.
-        :returns: True iff the file is free of table grouping errors.
+        :returns: `bool` of whether the file is free of table grouping errors.
         """
 
         LOGGER.debug('Assessing #OZONE_PROFILE, #GLOBAL_SUMMARY table counts')
@@ -548,7 +554,8 @@ class UmkehrValidator(DatasetValidator):
         tables and improper ordering of dates within their data tables.
 
         :param extcsv: A parsed Extended CSV file of Umkehr data.
-        :returns: True iff the file's dataset-specific tables are error-free.
+        :returns: `bool` of whether the file's dataset-specific tables
+                  are error-free.
         """
 
         LOGGER.info('Beginning Umkehr-specific checks')
@@ -565,7 +572,8 @@ class UmkehrValidator(DatasetValidator):
         #C_PROFILE) in <extcsv>. Returns True iff no errors were found.
 
         :param extcsv: A parsed Extended CSV file of Umkehr data.
-        :returns: True iff the ordering of observation dates is error-free.
+        :returns: `bool` of whether the ordering of observation dates
+                  is error-free.
         """
 
         level = extcsv.extcsv['CONTENT']['Level']
@@ -627,7 +635,7 @@ class UmkehrValidator(DatasetValidator):
         and inconsistencies. Returns True iff no errors were found.
 
         :param extcsv: A parsed Extended CSV file of Umkehr data.
-        :returns: True iff the two #TIMESTAMP tables are error-free.
+        :returns: `bool` of whether the two #TIMESTAMP tables are error-free.
         """
 
         LOGGER.debug('Assessing #TIMESTAMP tables for similarity')

--- a/woudc_data_registry/epicentre/deployment.py
+++ b/woudc_data_registry/epicentre/deployment.py
@@ -11,9 +11,7 @@ from woudc_data_registry.util import json_serial
 
 
 def build_deployment(ecsv):
-    """
-    Creates and returns a Deployment instance from the contents of <ecsv>
-    """
+    """Creates and returns a Deployment instance from the contents of <ecsv>"""
 
     station = str(ecsv.extcsv['PLATFORM']['ID'])
     agency = ecsv.extcsv['DATA_GENERATION']['Agency']

--- a/woudc_data_registry/epicentre/metadata.py
+++ b/woudc_data_registry/epicentre/metadata.py
@@ -62,7 +62,6 @@ def get_metadata(entity, identifier=None):
 
     :param entity: metadata entity
     :param identifier: identifier filter (default no filter)
-
     :returns: `list` of all matching objects
     """
 

--- a/woudc_data_registry/epicentre/metadata.py
+++ b/woudc_data_registry/epicentre/metadata.py
@@ -94,8 +94,9 @@ def add_metadata(entity, dict_, save_to_registry=True, save_to_index=True):
 
     :param entity: A model class.
     :param dict_: Dictionary of model data to initialize the object.
-    :param save_to_registry: Whether to load object to the data registry.
-    :param save_to_index: Whether to load object to the search index.
+    :param save_to_registry: `bool` of whether to load object
+                             to the data registry.
+    :param save_to_index: `bool` of whether to load object to the search index.
     :returns: The model object created.
     """
 
@@ -149,9 +150,11 @@ def update_metadata(entity, identifier, dict_,
     :param entity: A model class.
     :param identifier: Identifier of target object.
     :param dict_: Dictionary of model data to initialize the object.
-    :param save_to_registry: Whether to update object in the data registry.
-    :param save_to_index: Whether to update object in the search index.
-    :returns: Whether the operation was successful.
+    :param save_to_registry: `bool` of whether to update object in
+                             the data registry.
+    :param save_to_index: `bool` of whether to update object in
+                          the search index.
+    :returns: `bool` of whether the operation was successful.
     """
 
     records = get_metadata(entity, identifier)
@@ -205,9 +208,11 @@ def delete_metadata(entity, identifier,
 
     :param entity: A model class.
     :param identifier: Data registry identifier of target object.
-    :param save_to_registry: Whether changes should apply to the data registry.
-    :param save_to_index: Whether changes should apply to the search_index.
-    :returns: Whether the operation was successful.
+    :param save_to_registry: `bool` of whether changes should apply
+                             to the data registry.
+    :param save_to_index: `bool` of whether changes should apply
+                          to the search_index.
+    :returns: `bool` of whether the operation was successful.
     """
 
     LOGGER.debug('Updating metadata entity {}, identifier {}'.format(

--- a/woudc_data_registry/log.py
+++ b/woudc_data_registry/log.py
@@ -51,12 +51,11 @@ LOGGER = logging.getLogger(__name__)
 
 def setup_logger(loglevel, logfile=None):
     """
-    Setup configuration
+    Setup global logging configuration.
 
     :param loglevel: logging level
     :param logfile: logfile location
-
-    :returns: void (creates logging instance)
+    :returns: void
     """
 
     log_format = \

--- a/woudc_data_registry/models.py
+++ b/woudc_data_registry/models.py
@@ -1056,7 +1056,7 @@ def init(ctx, datadir, init_search_index):
 @click.command('sync')
 @click.pass_context
 def sync(ctx):
-    """ sync search index with data registry """
+    """Sync search index with data registry"""
 
     model_classes = [
         Project,

--- a/woudc_data_registry/parser.py
+++ b/woudc_data_registry/parser.py
@@ -83,6 +83,9 @@ def non_content_line(line):
     """
     Returns True iff <line> represents a non-content line of an Extended CSV
     file, i.e. a blank line or a comment.
+
+    :param line: List of comma-separated components in an input line.
+    :returns: False iff the line contains data.
     """
 
     if len(line) == 0:
@@ -108,7 +111,6 @@ class ExtendedCSV(object):
         read WOUDC Extended CSV file
 
         :param content: buffer of Extended CSV data
-
         :returns: `woudc_data_registry.parser.ExtendedCSV`
         """
 
@@ -188,6 +190,10 @@ class ExtendedCSV(object):
         """
         Returns the line in the source file at which <table> started.
         If there is no table in the file named <table>, returns None instead.
+
+        :param table: Name of an Extended CSV table.
+        :returns: The line number where the table occurs, or None if
+                  the table never occurs.
         """
 
         return self._line_num.get(table, None)
@@ -195,6 +201,9 @@ class ExtendedCSV(object):
     def table_count(self, table_type):
         """
         Returns the number of tables named <table_type> in the source file.
+
+        :param table_type: Name of an Extended CSV table without suffixes.
+        :returns: Number of tables named <table_type> in the input file.
         """
 
         return self._table_count.get(table_type, 0)
@@ -203,6 +212,11 @@ class ExtendedCSV(object):
         """
         Record <message> as an error with code <error_code> that took place
         at line <line> in the input file.
+
+        :param error_code: Numeric error code from the error definition files.
+        :param line: Line number in the input file where the error was found.
+        :param message: String message describing the error.
+        :returns: void
         """
 
         LOGGER.warning(message)
@@ -212,6 +226,11 @@ class ExtendedCSV(object):
         """
         Record <message> as an error with code <error_code> that took place
         at line <line> in the input file.
+
+        :param error_code: Numeric error code from the error definition files.
+        :param line: Line number in the input file where the error was found.
+        :param message: String message describing the error.
+        :returns: void
         """
 
         LOGGER.error(message)
@@ -251,12 +270,10 @@ class ExtendedCSV(object):
         Add the raw strings in <values> to the bottom of the columns
         in the tabled named <table_name>.
 
-        Returns a list of errors encountered while adding the new values.
-
         :param table_name: Name of the table the values fall under
         :param values: A list of values from one row in the table
         :param line_num: Line number the row occurs at
-        :returns: List of errors
+        :returns: void
         """
 
         fields = self.extcsv[table_name].keys()
@@ -278,6 +295,7 @@ class ExtendedCSV(object):
         Does not alter the source file in any way.
 
         :param table_name: Name of the table to delete.
+        :returns: void
         """
 
         table_type = table_name.rstrip('0123456789_')
@@ -642,6 +660,7 @@ class ExtendedCSV(object):
 
         :param tables: List of tables in which to process columns.
         :param schema: A series of table definitions for the input file.
+        :returns: void
         """
 
         for table_name in tables:
@@ -943,6 +962,7 @@ class ExtendedCSV(object):
 
         :param schema: Dictionary with nested dictionaries of
                        table definitions as values.
+        :returns: Version number for the best-fitting table definition.
         """
 
         versions = set(schema.keys())

--- a/woudc_data_registry/parser.py
+++ b/woudc_data_registry/parser.py
@@ -85,7 +85,7 @@ def non_content_line(line):
     file, i.e. a blank line or a comment.
 
     :param line: List of comma-separated components in an input line.
-    :returns: False iff the line contains data.
+    :returns: `bool` of whether the line contains no data.
     """
 
     if len(line) == 0:
@@ -687,7 +687,8 @@ class ExtendedCSV(object):
         Returns True iff all tables occur an acceptable number of times.
 
         :param schema: A series of table definitions for the input file.
-        :returns: Whether all tables are within the expected occurrence range.
+        :returns: `bool` of whether all tables are within the expected
+                  occurrence range.
         """
 
         success = True
@@ -722,7 +723,8 @@ class ExtendedCSV(object):
         :param table: Name of a table in the input file.
         :param definition: Schema definition of <table>.
         :param num_rows: The number of rows in <table>.
-        :returns: Whether all tables are in the expected height range.
+        :returns: `bool` of whether all tables are in the expected
+                  height range.
         """
 
         height_range = str(definition['rows'])
@@ -761,7 +763,7 @@ class ExtendedCSV(object):
 
         :param table: Name of a table in the input file.
         :param definition: Schema definition for the table.
-        :returns: Whether fields satisfy the table's definition.
+        :returns: `bool` of whether fields satisfy the table's definition.
         """
 
         success = True

--- a/woudc_data_registry/processing.py
+++ b/woudc_data_registry/processing.py
@@ -135,9 +135,11 @@ class Process(object):
         Process incoming data record.
 
         :param infile: Path to incoming data file.
-        :param metadata_only: Whether to only verify common metadata tables.
-        :param bypass: Whether to skip permission prompts to add records.
-        :returns: Whether the operation was successful.
+        :param metadata_only: `bool` of whether to only verify common
+                              metadata tables.
+        :param bypass: `bool` of whether to skip permission prompts
+                        to add records.
+        :returns: `bool` of whether the operation was successful.
         """
 
         # detect incoming data file
@@ -401,8 +403,9 @@ class Process(object):
         prompt before a record is created. If permission is denied, no
         station name will be queued and False will be returned.
 
-        :param bypass: Whether to skip permission checks to add the name.
-        :returns: Whether the operation was successful.
+        :param bypass: `bool` of whether to skip permission checks
+                       to add the name.
+        :returns: `bool` of whether the operation was successful.
         """
 
         station_name_object = build_station_name(self.extcsv)
@@ -433,8 +436,9 @@ class Process(object):
         prompt before a record is created. If permission is denied, no
         new instrument will be queued and False will be returned.
 
-        :param bypass: Whether to skip permission checks to add the instrument.
-        :returns: Whether the operation was successful.
+        :param bypass: `bool` of whether to skip permission checks
+                       to add the instrument.
+        :returns: `bool` of whether the operation was successful.
         """
 
         instrument = build_instrument(self.extcsv)
@@ -461,7 +465,8 @@ class Process(object):
         Validates the instance's Extended CSV source file's #CONTENT.Class,
         and returns True if no errors are found.
 
-        :returns: Whether the input file's project validated successfully.
+        :returns: `bool` of whether the input file's project
+                  validated successfully.
         """
 
         project = self.extcsv.extcsv['CONTENT']['Class']
@@ -486,7 +491,8 @@ class Process(object):
 
         Adjusts the Extended CSV contents if necessary to form a match.
 
-        :returns: Whether the input file's dataset validated successfully.
+        :returns: `bool` of whether the input file's dataset
+                  validated successfully.
         """
 
         dataset = self.extcsv.extcsv['CONTENT']['Category']
@@ -517,7 +523,8 @@ class Process(object):
 
         Prerequisite: #CONTENT.Class is a trusted value.
 
-        :returns: Whether the input file's contributor validated successfully.
+        :returns: `bool` of whether the input file's contributor
+                  validated successfully.
         """
 
         agency = self.extcsv.extcsv['DATA_GENERATION']['Agency']
@@ -564,7 +571,8 @@ class Process(object):
 
         Adjusts the Extended CSV contents if necessary to form a match.
 
-        :returns: Whether the input file's station validated successfully.
+        :returns: `bool` of whether the input file's station
+                  validated successfully.
         """
 
         identifier = str(self.extcsv.extcsv['PLATFORM']['ID'])
@@ -669,8 +677,8 @@ class Process(object):
                       #PLATFORM_ID, and
                       #CONTENT.Class are all trusted values.
 
-        :returns: Whether the input file's station-contributor pairing
-                  validated successfully.
+        :returns: `bool` of whether the input file's station-contributor
+                  pairing validated successfully.
         """
 
         station = str(self.extcsv.extcsv['PLATFORM']['ID'])
@@ -705,7 +713,7 @@ class Process(object):
 
         Adjusts the Extended CSV contents if necessary to form a match.
 
-        :returns: Whether the input file's instrument name and model
+        :returns: `bool` of whether the input file's instrument name and model
                   validated successfully.
         """
 
@@ -773,7 +781,7 @@ class Process(object):
                       #PLATFORM.ID and
                       #CONTENT.Category are all trusted values.
 
-        :returns: Whether the input file's instrument collectively
+        :returns: `bool` of whether the input file's instrument collectively
                   validated successfully.
         """
 
@@ -806,7 +814,8 @@ class Process(object):
         against the location of the instrument from the file, and returns
         True if no errors are found.
 
-        :returns: Whether the input file's location validated successfully.
+        :returns: `bool` of whether the input file's location
+                  validated successfully.
         """
 
         instrument_id = build_instrument(self.extcsv).instrument_id
@@ -902,8 +911,8 @@ class Process(object):
 
         Prerequisite: #CONTENT.Category is a trusted value.
 
-        :returns: Whether the input file's #CONTENT table collectively
-                  validated successfully.
+        :returns: `bool` of whether the input file's #CONTENT table
+                  collectively validated successfully.
         """
 
         dataset = self.extcsv.extcsv['CONTENT']['Category']
@@ -965,8 +974,8 @@ class Process(object):
 
         Fill in the Extended CSV with missing values if possible.
 
-        :returns: Whether the input file's #DATA_GENERATION table collectively
-                  validated successfully.
+        :returns: `bool` of whether the input file's #DATA_GENERATION table
+                  collectively validated successfully.
         """
 
         dg_date = self.extcsv.extcsv['DATA_GENERATION'].get('Date', None)
@@ -1023,7 +1032,7 @@ class Process(object):
         Validate the input Extended CSV source file's dates across all tables
         to ensure that no date is more recent that #DATA_GENERATION.Date.
 
-        :returns: Whether the input file's time fields collectively
+        :returns: `bool` of whether the input file's time fields collectively
                   validated successfully.
         """
 
@@ -1074,7 +1083,8 @@ class Process(object):
                       and #INSTRUMENT.Number are all trusted values
                       and self.data_record exists.
 
-        :returns: Whether the data record metadata validated successfully.
+        :returns: `bool` of whether the data record metadata validated
+                  successfully.
         """
 
         dg_date = self.extcsv.extcsv['DATA_GENERATION']['Date']

--- a/woudc_data_registry/processing.py
+++ b/woudc_data_registry/processing.py
@@ -106,6 +106,11 @@ class Process(object):
         """
         Record <message> as an error with code <error_code> that took place
         at line <line> in the input file.
+
+        :param error_code: Numeric error code from the error definition files.
+        :param line: Line number in the input file where the error was found.
+        :param message: String message describing the error.
+        :returns: void
         """
 
         LOGGER.warning(message)
@@ -115,6 +120,11 @@ class Process(object):
         """
         Record <message> as an error with code <error_code> that took place
         at line <line> in the input file.
+
+        :param error_code: Numeric error code from the error definition files.
+        :param line: Line number in the input file where the error was found.
+        :param message: String message describing the error.
+        :returns: void
         """
 
         LOGGER.error(message)
@@ -127,8 +137,7 @@ class Process(object):
         :param infile: Path to incoming data file.
         :param metadata_only: Whether to only verify common metadata tables.
         :param bypass: Whether to skip permission prompts to add records.
-
-        :returns: `bool` of processing result
+        :returns: Whether the operation was successful.
         """
 
         # detect incoming data file
@@ -324,6 +333,8 @@ class Process(object):
         Publish all changes from the previous file parse to the data registry
         and ElasticSearch index, including instrument/deployment updates.
         Copies the input file to the WAF.
+
+        :returns: void
         """
 
         data_records = []
@@ -370,6 +381,8 @@ class Process(object):
         Create a new deployment instance for the input Extended CSV file's
         #PLATFORM and #DATA_GENERATION.Agency. Queues the new deployment
         to be saved next time the publish method is called.
+
+        :returns: void
         """
 
         deployment = build_deployment(self.extcsv)
@@ -447,6 +460,8 @@ class Process(object):
         """
         Validates the instance's Extended CSV source file's #CONTENT.Class,
         and returns True if no errors are found.
+
+        :returns: Whether the input file's project validated successfully.
         """
 
         project = self.extcsv.extcsv['CONTENT']['Class']
@@ -470,7 +485,10 @@ class Process(object):
         and returns True if no errors are found.
 
         Adjusts the Extended CSV contents if necessary to form a match.
+
+        :returns: Whether the input file's dataset validated successfully.
         """
+
         dataset = self.extcsv.extcsv['CONTENT']['Category']
 
         LOGGER.debug('Validating dataset {}'.format(dataset))
@@ -498,6 +516,8 @@ class Process(object):
         Adjusts the Extended CSV contents if necessary to form a match.
 
         Prerequisite: #CONTENT.Class is a trusted value.
+
+        :returns: Whether the input file's contributor validated successfully.
         """
 
         agency = self.extcsv.extcsv['DATA_GENERATION']['Agency']
@@ -543,6 +563,8 @@ class Process(object):
         and returns True if no errors are found.
 
         Adjusts the Extended CSV contents if necessary to form a match.
+
+        :returns: Whether the input file's station validated successfully.
         """
 
         identifier = str(self.extcsv.extcsv['PLATFORM']['ID'])
@@ -646,6 +668,9 @@ class Process(object):
         Prerequisite: #DATA_GENERATION.Agency,
                       #PLATFORM_ID, and
                       #CONTENT.Class are all trusted values.
+
+        :returns: Whether the input file's station-contributor pairing
+                  validated successfully.
         """
 
         station = str(self.extcsv.extcsv['PLATFORM']['ID'])
@@ -679,6 +704,9 @@ class Process(object):
         and #INSTRUMENT.Model and returns True if no errors are found.
 
         Adjusts the Extended CSV contents if necessary to form a match.
+
+        :returns: Whether the input file's instrument name and model
+                  validated successfully.
         """
 
         name_ok = True
@@ -744,6 +772,9 @@ class Process(object):
                       #INSTRUMENT.Model,
                       #PLATFORM.ID and
                       #CONTENT.Category are all trusted values.
+
+        :returns: Whether the input file's instrument collectively
+                  validated successfully.
         """
 
         serial = self.extcsv.extcsv['INSTRUMENT']['Number']
@@ -774,6 +805,8 @@ class Process(object):
         Validates the instance's Extended CSV source file's #LOCATION table
         against the location of the instrument from the file, and returns
         True if no errors are found.
+
+        :returns: Whether the input file's location validated successfully.
         """
 
         instrument_id = build_instrument(self.extcsv).instrument_id
@@ -868,6 +901,9 @@ class Process(object):
         Fill is the Extended CSV with missing values if possible.
 
         Prerequisite: #CONTENT.Category is a trusted value.
+
+        :returns: Whether the input file's #CONTENT table collectively
+                  validated successfully.
         """
 
         dataset = self.extcsv.extcsv['CONTENT']['Category']
@@ -928,6 +964,9 @@ class Process(object):
         with other tables. Returns True if no errors were encountered.
 
         Fill in the Extended CSV with missing values if possible.
+
+        :returns: Whether the input file's #DATA_GENERATION table collectively
+                  validated successfully.
         """
 
         dg_date = self.extcsv.extcsv['DATA_GENERATION'].get('Date', None)
@@ -983,6 +1022,9 @@ class Process(object):
         """
         Validate the input Extended CSV source file's dates across all tables
         to ensure that no date is more recent that #DATA_GENERATION.Date.
+
+        :returns: Whether the input file's time fields collectively
+                  validated successfully.
         """
 
         dg_date = self.extcsv.extcsv['DATA_GENERATION']['Date']
@@ -1031,6 +1073,8 @@ class Process(object):
                       #INSTRUMENT.Name,
                       and #INSTRUMENT.Number are all trusted values
                       and self.data_record exists.
+
+        :returns: Whether the data record metadata validated successfully.
         """
 
         dg_date = self.extcsv.extcsv['DATA_GENERATION']['Date']

--- a/woudc_data_registry/registry.py
+++ b/woudc_data_registry/registry.py
@@ -100,7 +100,8 @@ class Registry(object):
         :param obj: Object instance of the table to query in
         :param by: Field name to be queried
         :param value: Value of the field in any query results
-        :param case_insensitive: Whether to query strings case-insensitively
+        :param case_insensitive: `bool` of whether to query strings
+                                 case-insensitively
         :returns: Query results
         """
 
@@ -124,7 +125,8 @@ class Registry(object):
         :param obj: Class of table to query in.
         :param by: Field name to be queried.
         :param pattern: Wildcard pattern that any result's value must match.
-        :param case_insensitive: Whether to query strings case-insensitively.
+        :param case_insensitive: `bool` of whether to query strings
+                                 case-insensitively.
         :returns: One element of query results.
         """
 

--- a/woudc_data_registry/registry.py
+++ b/woudc_data_registry/registry.py
@@ -85,7 +85,6 @@ class Registry(object):
         queries for distinct values
 
         :param domain: domain to be queried
-
         :returns: list of distinct values
         """
 
@@ -157,7 +156,6 @@ class Registry(object):
         :param fields: fields to be filtered by
         :param case_insensitive: Collection of string fields that should be
                                  queried case-insensitively
-
         :returns: query results
         """
 
@@ -181,7 +179,6 @@ class Registry(object):
         helper function to save object to registry
 
         :param obj: object to save (defualt None)
-
         :returns: void
         """
 
@@ -201,4 +198,6 @@ class Registry(object):
             self.session.rollback()
 
     def close_session(self):
+        """Close the registry's database connection and resources"""
+
         self.session.close()

--- a/woudc_data_registry/search.py
+++ b/woudc_data_registry/search.py
@@ -364,7 +364,6 @@ class SearchIndex(object):
         Generates index name with prefix if specified in config/environment
 
         :param index_name: ES index name
-
         :returns: fully qualified index name
         """
 
@@ -434,7 +433,6 @@ class SearchIndex(object):
         get version of data record
 
         :param identifier: identifier of data record
-
         :returns: `float` version of data record
         """
 

--- a/woudc_data_registry/search.py
+++ b/woudc_data_registry/search.py
@@ -454,7 +454,7 @@ class SearchIndex(object):
 
         :param domain: A model class that all entries in <target> belong to.
         :param target: GeoJSON dictionary of model data or a list of them.
-        :returns: Whether the operation was successful.
+        :returns: `bool` of whether the operation was successful.
         """
 
         if not MAPPINGS[domain.__tablename__]['enabled']:
@@ -501,7 +501,7 @@ class SearchIndex(object):
 
         :param domain: A model class that all entries in <target> belong to.
         :param target: GeoJSON dictionary of model data or a list of them.
-        :returns: Whether the operation was successful.
+        :returns: `bool` of whether the operation was successful.
         """
 
         if not MAPPINGS[domain.__tablename__]['enabled']:
@@ -550,7 +550,7 @@ class SearchIndex(object):
 
         :param domain: A model class that all entries in <target> belong to.
         :param target: List of GeoJSON model data.
-        :returns: Whether the operation was successful.
+        :returns: `bool` of whether the operation was successful.
         """
 
         if not MAPPINGS[domain.__tablename__]['enabled']:

--- a/woudc_data_registry/tests/test_data_registry.py
+++ b/woudc_data_registry/tests/test_data_registry.py
@@ -56,6 +56,9 @@ def resolve_test_data_path(test_data_file):
     """
     helper function to ensure filepath is valid
     for different testing context (setuptools, directly, etc.)
+
+    :param test_data_file: Relative path to an input file.
+    :returns: Full path to the input file.
     """
 
     if os.path.exists(test_data_file):
@@ -101,7 +104,7 @@ class ParserTest(unittest.TestCase):
             dummy.typecast_value('Dum', 'utcoffset', bad_input, 0), bad_input)
 
     def test_build_table(self):
-        """ Test table-management methods directly """
+        """Test table management methods directly"""
 
         ecsv = parser.ExtendedCSV('')
         fields = ['Class', 'Category', 'Level', 'Form']
@@ -152,7 +155,7 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(ecsv.extcsv, {})
 
     def test_row_filling(self):
-        """ Test that omitted columns in a row are filled in with nulls """
+        """Test that omitted columns in a row are filled in with nulls"""
 
         ecsv = parser.ExtendedCSV('')
         ecsv.init_table('TIMESTAMP', ['UTCOffset', 'Date', 'Time'], 1)
@@ -175,7 +178,7 @@ class ParserTest(unittest.TestCase):
             self.assertNotEqual(ecsv.extcsv['INSTRUMENT'][field][0], '')
 
     def test_field_capitalization(self):
-        """ Test that field names with incorrect capitalizations are fixed """
+        """Test that field names with incorrect capitalizations are fixed"""
 
         contents = util.read_file(resolve_test_data_path(
             'data/general/ecsv-field-capitalization.csv'))
@@ -206,7 +209,7 @@ class ParserTest(unittest.TestCase):
             self.assertEqual(len(ecsv.extcsv['DAILY'][field]), 30)
 
     def test_column_conversion(self):
-        """ Test that single-row tables are recognized and collimated """
+        """Test that single-row tables are recognized and collimated"""
 
         content_fields = ['Class', 'Category', 'Level', 'Form']
         content_values = ['WODUC', 'Broad-band', '1.0', '1']
@@ -257,7 +260,7 @@ class ParserTest(unittest.TestCase):
             self.assertIsInstance(value, float)
 
     def test_submissions(self):
-        """ Test parsing of previously submitted Extended CSV files """
+        """Test parsing of previously submitted Extended CSV files"""
 
         # Error-free file
         contents = util.read_file(resolve_test_data_path(
@@ -292,7 +295,7 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(ecsv.extcsv['PLATFORM']['Name'], 'Río Gallegos')
 
     def test_non_extcsv(self):
-        """ Test that various non-extcsv text files fail to parse """
+        """Test that various non-extcsv text files fail to parse"""
 
         # Text file is not in Extended CSV format
         contents = util.read_file(resolve_test_data_path(
@@ -311,7 +314,7 @@ class ParserTest(unittest.TestCase):
             ecsv.validate_metadata_tables()
 
     def test_missing_required_table(self):
-        """ Test that files with missing required tables fail to parse """
+        """Test that files with missing required tables fail to parse"""
 
         contents = util.read_file(resolve_test_data_path(
             'data/general/ecsv-missing-location-table.csv'))
@@ -323,7 +326,7 @@ class ParserTest(unittest.TestCase):
             ecsv.validate_metadata_tables()
 
     def test_missing_required_value(self):
-        """ Test that files with missing required values fail to parse """
+        """Test that files with missing required values fail to parse"""
 
         # File contains empty/null value for required field
         contents = util.read_file(resolve_test_data_path(
@@ -344,7 +347,7 @@ class ParserTest(unittest.TestCase):
             ecsv.validate_metadata_tables()
 
     def test_missing_optional_table(self):
-        """ Test that files with missing optional tables parse successfully """
+        """Test that files with missing optional tables parse successfully"""
 
         contents = util.read_file(resolve_test_data_path(
             'data/general/ecsv-missing-monthly-table.csv'))
@@ -358,7 +361,7 @@ class ParserTest(unittest.TestCase):
                         set(ecsv.extcsv.keys())))
 
     def test_missing_optional_value(self):
-        """ Test that files with missing optional values parse successfully """
+        """Test that files with missing optional values parse successfully"""
 
         # File contains empty/null value for optional LOCATION.Height
         contents = util.read_file(resolve_test_data_path(
@@ -380,7 +383,7 @@ class ParserTest(unittest.TestCase):
         self.assertIsNone(ecsv.extcsv['PLATFORM']['GAW_ID'])
 
     def test_empty_tables(self):
-        """ Test that files fail to parse if a table has no rows of values """
+        """Test that files fail to parse if a table has no rows of values"""
 
         contents = util.read_file(resolve_test_data_path(
             'data/general/ecsv-empty-timestamp2-table.csv'))
@@ -397,7 +400,7 @@ class ParserTest(unittest.TestCase):
             ecsv.validate_metadata_tables()
 
     def test_table_height(self):
-        """ Test that files fail to parse if a table has too many rows """
+        """Test that files fail to parse if a table has too many rows"""
 
         contents = util.read_file(resolve_test_data_path(
             'data/general/ecsv-excess-timestamp-table-rows.csv'))
@@ -407,7 +410,7 @@ class ParserTest(unittest.TestCase):
             ecsv.validate_metadata_tables()
 
     def test_table_occurrences(self):
-        """ Test that files fail to parse if a table appears too many times """
+        """Test that files fail to parse if a table appears too many times"""
 
         contents = util.read_file(resolve_test_data_path(
             'data/general/ecsv-excess-location-table.csv'))
@@ -417,7 +420,7 @@ class ParserTest(unittest.TestCase):
             ecsv.validate_metadata_tables()
 
     def test_line_spacing(self):
-        """ Test that files can parse no matter the space between tables """
+        """Test that files can parse no matter the space between tables"""
 
         contents = util.read_file(resolve_test_data_path(
             'data/general/ecsv-no-spaced.csv'))
@@ -434,7 +437,7 @@ class ParserTest(unittest.TestCase):
         self.assertTrue(set(DOMAINS['Common']).issubset(set(ecsv.extcsv)))
 
     def test_determine_version_broadband(self):
-        """ Test assigning a table definition version with multiple options """
+        """Test assigning a table definition version with multiple options"""
 
         contents = util.read_file(resolve_test_data_path(
             'data/general/20080101.Kipp_Zonen.UV-S-E-T.000560.PMOD-WRC.csv'))
@@ -465,7 +468,7 @@ class ParserTest(unittest.TestCase):
                 self.assertIn(param, ecsv.extcsv)
 
     def test_number_of_observations(self):
-        """ Test counting of observation rows in a generic file """
+        """Test counting of observation rows in a generic file"""
 
         # Test throughout various datasets with different data table names.
         contents = util.read_file(resolve_test_data_path(
@@ -495,7 +498,7 @@ class ParserTest(unittest.TestCase):
         self.assertEquals(ecsv.number_of_observations(), 719)
 
     def test_number_of_observations_large(self):
-        """ Test counting of observation rows in a file with large tables """
+        """Test counting of observation rows in a file with large tables"""
 
         contents = util.read_file(resolve_test_data_path(
             'data/general/20040709.ECC.2Z.2ZL1.NOAA-CMDL.csv'))
@@ -506,7 +509,7 @@ class ParserTest(unittest.TestCase):
         self.assertEquals(ecsv.number_of_observations(), 5295)
 
     def test_number_of_observations_duplicates(self):
-        """ Test counting of observation rows in a file with duplicate rows """
+        """Test counting of observation rows in a file with duplicate rows"""
 
         contents = util.read_file(resolve_test_data_path(
             'data/umkehr/umkehr1-duplicated.csv'))
@@ -541,7 +544,7 @@ class ParserTest(unittest.TestCase):
 
 
 class TimestampParsingTest(unittest.TestCase):
-    """ Test suite for parser.ExtendedCSV._parse_timestamp """
+    """Test suite for parser.ExtendedCSV._parse_timestamp"""
 
     def setUp(self):
         # Only need a dummy parser since no input is coming from files.
@@ -551,7 +554,7 @@ class TimestampParsingTest(unittest.TestCase):
         return self.parser.parse_timestamp('Dummy', raw_string, 0)
 
     def test_success(self):
-        """ Test parsing valid timestamps """
+        """Test parsing valid timestamps"""
 
         self.assertEqual(self._parse_timestamp('00:00:00'), time(hour=0))
         self.assertEqual(self._parse_timestamp('12:00:00'), time(hour=12))
@@ -569,7 +572,7 @@ class TimestampParsingTest(unittest.TestCase):
                          time(hour=9, minute=15))
 
     def test_invalid_parts(self):
-        """ Test parsing timestamps fails with non-numeric characters """
+        """Test parsing timestamps fails with non-numeric characters"""
 
         with self.assertRaises(ValueError):
             self._parse_timestamp('0a:00:00')
@@ -585,8 +588,8 @@ class TimestampParsingTest(unittest.TestCase):
 
     def test_out_of_range(self):
         """
-        Test parsing timestamps where components have
-        invalid numeric values
+        Test parsing timestamps where components have invalid
+        numeric values
         """
 
         self.assertEqual(self._parse_timestamp('08:15:60'),
@@ -609,7 +612,7 @@ class TimestampParsingTest(unittest.TestCase):
                          time(hour=19, minute=25, second=1))
 
     def test_bad_separators(self):
-        """ Test parsing timestamps with separators other than ':' """
+        """Test parsing timestamps with separators other than ':'"""
 
         self.assertEqual(self._parse_timestamp('01-30-00'),
                          time(hour=1, minute=30))
@@ -622,7 +625,7 @@ class TimestampParsingTest(unittest.TestCase):
                          time(hour=1, minute=30))
 
     def test_12_hour_clock(self):
-        """ Test parsing timestamps which use am/pm format """
+        """Test parsing timestamps which use am/pm format"""
 
         self.assertEqual(self._parse_timestamp('01:00:00 am'), time(hour=1))
         self.assertEqual(self._parse_timestamp('01:00:00 pm'), time(hour=13))
@@ -637,7 +640,7 @@ class TimestampParsingTest(unittest.TestCase):
 
 
 class DatestampParsingTest(unittest.TestCase):
-    """ Test suite for parser.ExtendedCSV._parse_datestamp """
+    """Test suite for parser.ExtendedCSV._parse_datestamp"""
 
     def setUp(self):
         # Only need a dummy parser since no input is coming from files.
@@ -647,7 +650,7 @@ class DatestampParsingTest(unittest.TestCase):
         return self.parser.parse_datestamp('Dummy', raw_string, 0)
 
     def test_success(self):
-        """ Test parsing valid dates """
+        """Test parsing valid dates"""
 
         self.assertEqual(self._parse_datestamp('2013-05-01'),
                          date(year=2013, month=5, day=1))
@@ -664,7 +667,7 @@ class DatestampParsingTest(unittest.TestCase):
                          present)
 
     def test_invalid_parts(self):
-        """ Test parsing dates fails with non-numeric characters """
+        """Test parsing dates fails with non-numeric characters"""
 
         with self.assertRaises(ValueError):
             self._parse_datestamp('2019AD-10-31')
@@ -679,7 +682,7 @@ class DatestampParsingTest(unittest.TestCase):
             self._parse_datestamp('A generic string')
 
     def test_out_of_range(self):
-        """ Test parsing dates where components have invalid numeric values """
+        """Test parsing dates where components have invalid numeric values"""
 
         with self.assertRaises(ValueError):
             self._parse_datestamp('2001-04-35')
@@ -694,7 +697,7 @@ class DatestampParsingTest(unittest.TestCase):
             self._parse_datestamp('2003-00-01')
 
     def test_bad_separators(self):
-        """ Test parsing dates with separators other than '-' """
+        """Test parsing dates with separators other than '-'"""
 
         self.assertEqual(self._parse_datestamp('2019/01/24'),
                          date(year=2019, month=1, day=24))
@@ -709,7 +712,7 @@ class DatestampParsingTest(unittest.TestCase):
                          date(year=2019, month=1, day=24))
 
     def test_number_of_parts(self):
-        """ Test parsing dates with incorrect numbers of components """
+        """Test parsing dates with incorrect numbers of components"""
 
         with self.assertRaises(ValueError):
             self._parse_datestamp('20190124')
@@ -727,7 +730,7 @@ class DatestampParsingTest(unittest.TestCase):
 
 
 class UTCOffsetParsingTest(unittest.TestCase):
-    """ Test suite for parser.ExtendedCSV._parse_utcoffset """
+    """Test suite for parser.ExtendedCSV._parse_utcoffset"""
 
     def setUp(self):
         # Only need a dummy parser since no input is coming from files.
@@ -737,7 +740,7 @@ class UTCOffsetParsingTest(unittest.TestCase):
         return self.parser.parse_utcoffset('Dummy', raw_string, 0)
 
     def test_success(self):
-        """ Test parsing valid UTC offsets """
+        """Test parsing valid UTC offsets"""
 
         candidates = [
             '+09:00:00',
@@ -751,7 +754,7 @@ class UTCOffsetParsingTest(unittest.TestCase):
             self.assertEqual(self._parse_offset(candidate), candidate)
 
     def test_sign_variation(self):
-        """ Test parsing UTC offsets with various signs (or lacks thereof) """
+        """Test parsing UTC offsets with various signs (or lacks thereof)"""
         self.assertEqual(self._parse_offset('+05:30:00'), '+05:30:00')
         self.assertEqual(self._parse_offset('05:30:00'), '+05:30:00')
 
@@ -764,7 +767,7 @@ class UTCOffsetParsingTest(unittest.TestCase):
         self.assertEqual(self._parse_offset('00:00:00'), '+00:00:00')
 
     def test_missing_parts(self):
-        """ Test parsing UTC offsets where not all parts are provided. """
+        """Test parsing UTC offsets where not all parts are provided."""
 
         self.assertEqual(self._parse_offset('+13:00:'), '+13:00:00')
         self.assertEqual(self._parse_offset('+13::'), '+13:00:00')
@@ -781,7 +784,7 @@ class UTCOffsetParsingTest(unittest.TestCase):
             self._parse_offset('::')
 
     def test_part_lengths(self):
-        """ Test parsing UTC offsets where some parts are not 2 digits long """
+        """Test parsing UTC offsets where some parts are not 2 digits long"""
 
         self.assertEqual(self._parse_offset('+0:00:00'), '+00:00:00')
         self.assertEqual(self._parse_offset('+8:00:00'), '+08:00:00')
@@ -799,7 +802,7 @@ class UTCOffsetParsingTest(unittest.TestCase):
             self._parse_offset('-09:00:314159')
 
     def test_out_of_range(self):
-        """ Test that UTC offsets with invalid numeric parts fail to parse """
+        """Test that UTC offsets with invalid numeric parts fail to parse"""
 
         with self.assertRaises(ValueError):
             self._parse_offset('+60:00:00')
@@ -809,7 +812,7 @@ class UTCOffsetParsingTest(unittest.TestCase):
             self._parse_offset('-00:00:10800')
 
     def test_missing_separators(self):
-        """ Test parsing UTC offsets where there are fewer than 3 parts """
+        """Test parsing UTC offsets where there are fewer than 3 parts"""
 
         self.assertEqual(self._parse_offset('-03:30'), '-03:30:00')
         self.assertEqual(self._parse_offset('06:15'), '+06:15:00')
@@ -823,7 +826,7 @@ class UTCOffsetParsingTest(unittest.TestCase):
         self.assertEqual(self._parse_offset('-000000'), '+00:00:00')
 
     def test_bad_separators(self):
-        """ Test parsing dates with separators other than '-' """
+        """Test parsing dates with separators other than '-'"""
 
         self.assertEqual(self._parse_offset('+02|45|00'), '+02:45:00')
         self.assertEqual(self._parse_offset('+02/45/00'), '+02:45:00')
@@ -833,7 +836,7 @@ class UTCOffsetParsingTest(unittest.TestCase):
         self.assertEqual(self._parse_offset('+02/45|00'), '+02:45:00')
 
     def test_invalid_parts(self):
-        """ Test parsing UTC offsets which contain non-numeric characters """
+        """Test parsing UTC offsets which contain non-numeric characters"""
 
         with self.assertRaises(ValueError):
             self._parse_offset('-08:00:4A')
@@ -847,10 +850,10 @@ class UTCOffsetParsingTest(unittest.TestCase):
 
 
 class DatasetValidationTest(unittest.TestCase):
-    """ Test suite for dataset-specific validation checks and corrections """
+    """Test suite for dataset-specific validation checks and corrections"""
 
     def test_get_validator(self):
-        """ Test that get_validator returns the correct Validator classes """
+        """Test that get_validator returns the correct Validator classes"""
 
         datasets = ['Broad-band', 'Lidar', 'Multi-band', 'OzoneSonde',
                     'RocketSonde', 'Spectral', 'TotalOzone', 'TotalOzoneObs']
@@ -870,7 +873,7 @@ class DatasetValidationTest(unittest.TestCase):
             dv.get_validator('a generic string')
 
     def test_totalozone_checks(self):
-        """ Test that TotalOzone checks produce expected warnings/errors """
+        """Test that TotalOzone checks produce expected warnings/errors"""
 
         # Test a file with unique, out-of-order dates
         contents = util.read_file(resolve_test_data_path(
@@ -969,7 +972,7 @@ class DatasetValidationTest(unittest.TestCase):
         self.assertEqual(len(validator.errors), 0)
 
     def test_totalozone_monthly_generation(self):
-        """ Test derivation and checks related to TotalOzone MONTHLY table """
+        """Test derivation and checks related to TotalOzone MONTHLY table"""
 
         contents = util.read_file(resolve_test_data_path(
             'data/totalozone/totalozone-all300.csv'))
@@ -995,7 +998,7 @@ class DatasetValidationTest(unittest.TestCase):
         self.assertEqual(len(messages), 2)
 
     def test_totalozoneobs_checks(self):
-        """ Test that TotalOzoneObs checks produce expected warnings/errors """
+        """Test that TotalOzoneObs checks produce expected warnings/errors"""
 
         # Test that out-of-order observation times are found and corrected
         contents = util.read_file(resolve_test_data_path(
@@ -1044,7 +1047,7 @@ class DatasetValidationTest(unittest.TestCase):
         self.assertEqual(len(validator.errors), 0)
 
     def test_spectral_checks(self):
-        """ Test that Spectral checks produce warnings/errors when expected """
+        """Test that Spectral checks produce warnings/errors when expected"""
 
         # Test that an excess profile table is detected
         contents = util.read_file(resolve_test_data_path(
@@ -1099,7 +1102,7 @@ class DatasetValidationTest(unittest.TestCase):
         self.assertEqual(len(messages), 0)
 
     def test_lidar_checks(self):
-        """ Test that Lidar checks produce warnings/errors when expected """
+        """Test that Lidar checks produce warnings/errors when expected"""
 
         # Test that an excess profile table is detected
         contents = util.read_file(resolve_test_data_path(
@@ -1250,12 +1253,12 @@ class DatasetValidationTest(unittest.TestCase):
         self.assertEqual(len(validator.errors), 0)
 
     def test_umkehr_level1_checks(self):
-        """ Test that expected warnings/errors are found in Umkehr Level 1 """
+        """Test that expected warnings/errors are found in Umkehr Level 1"""
 
         self._helper_test_umkehr(1.0)
 
     def test_umkehr_level2_checks(self):
-        """ Test that expected warnings/errors are found in Umkehr Level 2 """
+        """Test that expected warnings/errors are found in Umkehr Level 2"""
 
         self._helper_test_umkehr(2.0)
 

--- a/woudc_data_registry/util.py
+++ b/woudc_data_registry/util.py
@@ -57,7 +57,6 @@ def point2geojsongeometry(x, y, z=None):
     :param x: x coordinate
     :param y: y coordinate
     :param z: y coordinate (default=None)
-
     :returns: `dict` of GeoJSON geometry
     """
 
@@ -85,7 +84,6 @@ def read_file(filename, encoding='utf-8'):
 
     :param filename: filename
     :param encoding: encoding (default=utf-8)
-
     :returns: buffer of file contents
     """
 
@@ -107,7 +105,6 @@ def str2bool(value):
     type (source: https://stackoverflow.com/a/715468)
 
     :param value: value to be evaluated
-
     :returns: `bool` of whether the value is boolean-ish
     """
 
@@ -147,7 +144,6 @@ def is_text_file(file_):
     detect if file is of type text
 
     :param file_: file to be tested
-
     :returns: `bool` of whether the file is text
     """
 
@@ -162,7 +158,6 @@ def is_binary_string(string_):
     detect if string is binary (https://stackoverflow.com/a/7392391)
 
     :param string_: `str` to be evaluated
-
     :returns: `bool` of whether the string is binary
     """
 
@@ -180,7 +175,6 @@ def json_serial(obj):
     types (source: https://stackoverflow.com/a/22238613)
 
     :param obj: `object` to be evaluate
-
     :returns: JSON non-default type to `str`
     """
 
@@ -198,7 +192,6 @@ def is_plural(value):
     helps function to determine whether a value is plural or singular
 
     :param value: value to be evaluated
-
     :returns: `bool` of whether the value is plural
     """
 


### PR DESCRIPTION
Ensured all multi-line docstrings had :returns: and any required :param: tags, and that single-line docstrings had no surrounding spaces.