### PR TITLE
Report Generation Skeleton

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ env:
     - WDR_WAF_BASEURL=https://woudc.org/archive/
     - WDR_WAF_BASEDIR=/tmp
     - WDR_TABLE_SCHEMA=$TRAVIS_BUILD_DIR/data/tables-schema.json
-    - WDR_TABLE_CONFIG=$TRAVIS_BUILD_DIR/data/tables.yml
-    - WDR_ERROR_CONFIG=$TRAVIS_BUILD_DIR/data/errors.csv
+    - WDR_TABLE_CONFIG=$TRAVIS_BUILD_DIR/data/migrate/tables-backfilling.yml
+    - WDR_ERROR_CONFIG=$TRAVIS_BUILD_DIR/data/migrate/errors-backfilling.csv
     - WDR_ALIAS_CONFIG=$TRAVIS_BUILD_DIR/data/aliases.yml
     - WDR_EXTRA_CONFIG=$TRAVIS_BUILD_DIR/data/extra-options.yml
 

--- a/README.md
+++ b/README.md
@@ -129,25 +129,25 @@ woudc-data-registry instrument update --help
 
 ```bash
 # ingest directory of files (walks directory recursively)
-woudc-data-registry data ingest -d /path/to/dir
+woudc-data-registry data ingest /path/to/dir
 
 # ingest single file
-woudc-data-registry data ingest -f foo.dat
+woudc-data-registry data ingest foo.dat
 
 # ingest without asking permission checks
-woudc-data-registry data ingest -f foo.dat -y
+woudc-data-registry data ingest foo.dat -y
 
 # verify directory of files (walks directory recursively)
-woudc-data-registry data verify -d /path/to/dir
+woudc-data-registry data verify /path/to/dir
 
 # verify single file
-woudc-data-registry data verify -f foo.dat
+woudc-data-registry data verify foo.dat
 
 # verify core metadata only
-woudc-data-registry data verify -f foo.dat -l
+woudc-data-registry data verify foo.dat -l
 
 # ingest with only core metadata checks
-woudc-data-registry data ingest -d /path/to/dir -l
+woudc-data-registry data ingest /path/to/dir -l
 ```
 
 ### Development

--- a/data/migrate/errors-backfilling.csv
+++ b/data/migrate/errors-backfilling.csv
@@ -1,21 +1,21 @@
 Error Code,Error Type,Message Template,Notes
-1,Error,Not a text file
+1,Warning,Not a text file
 2,Error,No core metadata tables found. Not an Extended CSV file
 3,Error,Missing required table #{table}
 4,Error,Excess table #{table} does not belong in {dataset} file
 5,Error,Missing required field #{table}.{field}
-6,Error,Excess field {field} does not belong in table {table}
+6,Warning,Excess field {field} does not belong in table {table}
 7,Error,Required field #{table}.{field} is null or empty
 8,Warning,Optional field #{table}.{field} is null or empty
 9,Error,Table #{table} has no fields
 10,Error,Table #{table} has no fields,Placeholder for optional-table-specific error
 11,Error,Required table #{table} contains no data
-12,Error,Optional table #{table} contains no data
+12,Warning,Optional table #{table} contains no data
 13,Error,No non-core data tables found
-14,Error,Unexpected empty line between table header and fields
+14,Warning,Unexpected empty line between table header and fields
 15,Error,Unrecognized data {row}
 16,Warning,Improper delimiter used '{separator}' corrected to '\,' (comma)
-20,Error,#{table} field {oldfield} capitalization should be {newfield}
+20,Warning,#{table} field {oldfield} capitalization should be {newfield}
 21,Warning,#{table} corrected to {newtable} using aliases
 22,Warning,#{table} field {oldfield} corrected to {newfield} using aliases
 23,Warning,#{table}.{field} value corrected to {newvalue} using aliases
@@ -24,25 +24,25 @@ Error Code,Error Type,Message Template,Notes
 27,Error,More than maximum {bound} occurrences of table #{table} found
 28,Error,Fewer than minimum {bound} number of rows in table #{table}
 29,Error,More than maximum {bound} number of rows in table #{table}
-30,Error,#{table}.Time separator '{separator}' corrected to ':' (colon)
+30,Warning,#{table}.Time separator '{separator}' corrected to ':' (colon)
 31,Error,Failed to parse #{table}.Time {component}: contains invalid characters
-32,Error,#{table}.Time corrected from 12-hour clock to 24-hour YYYY-MM-DD format
-33,Error,#{table}.Time {component} is not within allowable range [{lower}]-[{upper}]
-34,Error,#{table}.Date separator '{separator}' corrected to '-' (hyphen)
+32,Warning,#{table}.Time corrected from 12-hour clock to 24-hour YYYY-MM-DD format
+33,Warning,#{table}.Time {component} is not within allowable range [{lower}]-[{upper}]
+34,Warning,#{table}.Date separator '{separator}' corrected to '-' (hyphen)
 35,Error,#{table}.Date not in YYYY-MM-DD format: missing separators
 36,Error,#{table}.Date is incomplete
 37,Error,#{table}.Date not in YYYY-MM-DD format: too many separators
 38,Error,Failed to parse #{table}.Date {component}: contains invalid characters
 39,Error,#{table}.Date {component} is not within allowable range [{lower}]-[{upper}],Reserved for year and month components
 40,Error,#{table}.Date day is not within allowable range [{lower}]-[{upper}]
-41,Error,#{table}.UTCOffset separator '{separator}' corrected to ':' (colon)
-42,Error,#{table}.UTCOffset {component} is less than 2 digits long
-43,Error,#{table}.UTCOffset {component} is missing\, default value is '00' (zero)
-44,Error,Missing sign in #{table}.UTCOffset\, default '+' (plus)
-45,Error,Invalid sign in #{table}.UTCOffset\, replacing with '{sign}'
-46,Error,#{table}.UTCOffset is a series of zeroes\, should be '+00:00:00'
+41,Warning,#{table}.UTCOffset separator '{separator}' corrected to ':' (colon)
+42,Warning,#{table}.UTCOffset {component} is less than 2 digits long
+43,Warning,#{table}.UTCOffset {component} is missing\, default value is '00' (zero)
+44,Warning,Missing sign in #{table}.UTCOffset\, default '+' (plus)
+45,Warning,Invalid sign in #{table}.UTCOffset\, replacing with '{sign}'
+46,Warning,#{table}.UTCOffset is a series of zeroes\, should be '+00:00:00'
 47,Error,Failed to parse #{table}.UTCOffset: contains invalid characters
-50,Error,Missing #CONTENT.Class\, default is 'WOUDC'
+50,Warning,Missing #CONTENT.Class\, default is 'WOUDC'
 51,Error,#CONTENT.Class {value} failed to validate against registry
 52,Error,#CONTENT.Category {value} failed to validate against registry
 53,Warning,#CONTENT.Level should be {value} according to present tables
@@ -54,8 +54,8 @@ Error Code,Error Type,Message Template,Notes
 59,Error,Cannot resolve missing or invalid #CONTENT.Form
 60,Error,Unknown #CONTENT.Form for dataset {dataset} and level {level}
 61,Error,Cannot assess expected table set: #CONTENT.{field} unknown
-62,Error,Missing #DATA_GENERATION.Date\, defaulting to processing date
-63,Error,Missing #DATA_GENERATION.Version\, defaulting to {default}
+62,Warning,Missing #DATA_GENERATION.Date\, defaults to processing date
+63,Warning,Missing #DATA_GENERATION.Version\, defaults to {default}
 64,Warning,#DATA_GENERATION.Version is not within allowable range [{lower}]-[{upper}]
 65,Warning,#DATA_GENERATION.Version does not have exactly decimal place
 66,Error,Failed to parse #DATA_GENERATION.Version: contains invalid characters
@@ -67,13 +67,13 @@ Error Code,Error Type,Message Template,Notes
 74,Error,#PLATFORM.Country in file does not match registry
 75,Warning,Ship #PLATFORM.Country should be 'XY' to meet ISO-3166 standards
 76,Error,Failed to parse #LOCATION.{field}: contains invalid characters,Reserved for fields Latitude and Longitude
-77,Error,Failed to parse #LOCATION.Height: contains invalid characters
+77,Warning,Failed to parse #LOCATION.Height: contains invalid characters
 78,Error,#LOCATION.{field} is not within allowable range [{lower}]-[{upper}],Reserved for fields Latitude and Longitude
 79,Warning,#LOCATION.Height is not within allowable range [{lower}]-[{upper}]
-80,Error,#LOCATION.{field} in file does not match registry,Reserved for fields Latitude and Longitude
+80,Warning,#LOCATION.{field} in file does not match registry,Reserved for fields Latitude and Longitude
 81,Warning,#LOCATION.Height in file does not match registry
 82,Error,Null value found for #INSTRUMENT.Name
-83,Error,Null value found for #INSTRUMENT.Model
+83,Warning,Null value found for #INSTRUMENT.Model
 84,Warning,Null value found for #INSTRUMENT.Number
 85,Error,#INSTRUMENT.Name not found in registry
 86,Error,#INSTRUMENT.Model not found in registry
@@ -81,9 +81,9 @@ Error Code,Error Type,Message Template,Notes
 88,Error,Deployment {ident} not found in registry
 89,Error,Failed to parse #{table}.{field} due to errors: {reason}
 90,Warning,Inconsistent Time values between #TIMESTAMP tables
-91,Error,#{table}.Date cannot be more recent than #DATA_GENERATION.Date,Reserved for TIMESTAMP tables
-92,Error,#{table}.Date cannot be more recent than #DATA_GENERATION.Date,Reserved for non-TIMESTAMP tables
-93,Error,First #TIMESTAMP.Time cannot be more recent than other time(s)
+91,Warning,#{table}.Date cannot be more recent than #DATA_GENERATION.Date,Reserved for TIMESTAMP tables
+92,Warning,#{table}.Date cannot be more recent than #DATA_GENERATION.Date,Reserved for non-TIMESTAMP tables
+93,Warning,First #TIMESTAMP.Time cannot be more recent than other time(s)
 95,Error,Submitted file #DATA_GENERATION.Date is earlier than previously submitted version
 96,Error,Submitted file version and #DATA_GENERAION.Date identical to previously submitted file
 97,Error,Submitted #DATA_GENERATION.Date is identical to previously submitted file
@@ -92,22 +92,22 @@ Error Code,Error Type,Message Template,Notes
 101,Error,No ozone data in #DAILY table
 102,Warning,#DAILY.Date found in non-chronological order
 103,Warning,#DAILY.Date has different year than #TIMESTAMP.Date
-104,Warning,Duplicate observations found in #DAILY table
-105,Warning,Multiple observations found with #DAILY.Date {value}
+104,Warning,Duplicate observations found in #DAILY table for Date={date}
+105,Warning,Multiple observations found with #DAILY.Date {date}
 106,Warning,#TIMESTAMP.Date before #DAILY does not equal first date of #DAILY
 107,Warning,#TIMESTAMP.Date after #DAILY does not equal last date of #DAILY
 108,Warning,More than two #TIMESTAMP tables found in file
 109,Warning,#TIMESTAMP table after #DAILY is missing\, deriving based on requirements
 110,Warning,Missing #MONTHLY table\, deriving based on requirements
 111,Warning,Missing value for #MONTHLY.{field}\, deriving based on requirements
-112,Error,#MONTHLY.{field} differs from derived value
+112,Warning,#MONTHLY.{field} differs from derived value
 113,Error,Cannot derive #MONTHLY table: missing #DAILY.ColumnO3
 114,Warning,#OBSERVATIONS.Time found in non-chronological order
-115,Warning,Duplicate observations found in #OBSERVATIONS table
-116,Warning,Multiple observations found with #OBSERVATIONS.Time {value}
+115,Warning,Duplicate observations found in #OBSERVATIONS table for Time={time}
+116,Warning,Multiple observations found with #OBSERVATIONS.Time {time}
 118,Warning,#{table}.Date found in non-chronological order,Reserved for Umkehr data tables
-119,Warning,Duplicate observations found in #{table} table,Reserved for Umkehr data tables
-120,Warning,Multiple observations found with #{table}.Date {value},Reserved for Umkehr data tables
+119,Warning,Duplicate observations found in #{table} for Date={date},Reserved for Umkehr data tables
+120,Warning,Multiple observations found with #{table}.Date {date},Reserved for Umkehr data tables
 121,Warning,#TIMESTAMP.Date before #{table} does not equal first date of #{table},Reserved for Umkehr data tables
 122,Warning,#TIMESTAMP.Date after #{table} does not equal last date of #{table},Reserved for Umkehr data tables
 123,Warning,#TIMESTAMP table after #{table} is missing\, deriving based on requirements,Reserved for Umkehr data tables
@@ -117,4 +117,5 @@ Error Code,Error Type,Message Template,Notes
 201,Warning,New instrument added
 202,Warning,New deployment added
 203,Warning,New station name added
+209,Error,Data file failed to validate
 1000,Error,Unassigned error message

--- a/data/migrate/tables-backfilling.yml
+++ b/data/migrate/tables-backfilling.yml
@@ -427,7 +427,7 @@ Datasets:
             - TempC
             - F324
         DAILY_SUMMARY:
-          rows: 1
+          rows: 1+
           occurrences: 1
           required_fields:
             - WLCode
@@ -486,7 +486,7 @@ Datasets:
               - Sky_condition
           GLOBAL:
             rows: 1+
-            occurrences: 1
+            occurrences: 1+
             required_fields:
               - Wavelength
               - S-Irradiance

--- a/data/tables.yml
+++ b/data/tables.yml
@@ -415,7 +415,7 @@ Datasets:
             - TempC
             - F324
         DAILY_SUMMARY:
-          rows: 1
+          rows: 1+
           occurrences: 1
           required_fields:
             - WLCode

--- a/woudc_data_registry/epicentre/deployment.py
+++ b/woudc_data_registry/epicentre/deployment.py
@@ -1,3 +1,47 @@
+# =================================================================
+#
+# Terms and Conditions of Use
+#
+# Unless otherwise noted, computer program source code of this
+# distribution # is covered under Crown Copyright, Government of
+# Canada, and is distributed under the MIT License.
+#
+# The Canada wordmark and related graphics associated with this
+# distribution are protected under trademark law and copyright law.
+# No permission is granted to use them outside the parameters of
+# the Government of Canada's corporate identity program. For
+# more information, see
+# http://www.tbs-sct.gc.ca/fip-pcim/index-eng.asp
+#
+# Copyright title to all 3rd party software distributed with this
+# software is held by the respective copyright holders as noted in
+# those files. Users are asked to read the 3rd Party Licenses
+# referenced with those assets.
+#
+# Copyright (c) 2019 Government of Canada
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
 
 import click
 from datetime import date

--- a/woudc_data_registry/epicentre/instrument.py
+++ b/woudc_data_registry/epicentre/instrument.py
@@ -1,3 +1,47 @@
+# =================================================================
+#
+# Terms and Conditions of Use
+#
+# Unless otherwise noted, computer program source code of this
+# distribution # is covered under Crown Copyright, Government of
+# Canada, and is distributed under the MIT License.
+#
+# The Canada wordmark and related graphics associated with this
+# distribution are protected under trademark law and copyright law.
+# No permission is granted to use them outside the parameters of
+# the Government of Canada's corporate identity program. For
+# more information, see
+# http://www.tbs-sct.gc.ca/fip-pcim/index-eng.asp
+#
+# Copyright title to all 3rd party software distributed with this
+# software is held by the respective copyright holders as noted in
+# those files. Users are asked to read the 3rd Party Licenses
+# referenced with those assets.
+#
+# Copyright (c) 2019 Government of Canada
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
 
 import click
 import json
@@ -25,6 +69,7 @@ def build_instrument(ecsv):
     dataset = ecsv.extcsv['CONTENT']['Category']
     location = [ecsv.extcsv['LOCATION'].get(f, None)
                 for f in ['Longitude', 'Latitude', 'Height']]
+    timestamp_date = ecsv.extcsv['TIMESTAMP']['Date']
 
     instrument_id = ':'.join([name, model, serial, station, dataset])
     model = {
@@ -34,6 +79,8 @@ def build_instrument(ecsv):
         'serial': serial,
         'station_id': station,
         'dataset_id': dataset,
+        'start_date': timestamp_date,
+        'end_date': timestamp_date,
         'x': location[0],
         'y': location[1],
         'z': location[2]

--- a/woudc_data_registry/models.py
+++ b/woudc_data_registry/models.py
@@ -881,8 +881,8 @@ class DataRecord(base):
 
                 'timestamp_utcoffset': self.timestamp_utcoffset,
                 'timestamp_date': self.timestamp_date,
-                'timestamp_time': None if self.timestamp_time is None
-                                  else self.timestamp_time.isoformat(),
+                'timestamp_time': None if self.timestamp_time is None \
+                    else self.timestamp_time.isoformat(),
 
                 'published': self.published,
                 'received_datetime': self.received_datetime,

--- a/woudc_data_registry/report.py
+++ b/woudc_data_registry/report.py
@@ -1,0 +1,183 @@
+# =================================================================
+#
+# Terms and Conditions of Use
+#
+# Unless otherwise noted, computer program source code of this
+# distribution # is covered under Crown Copyright, Government of
+# Canada, and is distributed under the MIT License.
+#
+# The Canada wordmark and related graphics associated with this
+# distribution are protected under trademark law and copyright law.
+# No permission is granted to use them outside the parameters of
+# the Government of Canada's corporate identity program. For
+# more information, see
+# http://www.tbs-sct.gc.ca/fip-pcim/index-eng.asp
+#
+# Copyright title to all 3rd party software distributed with this
+# software is held by the respective copyright holders as noted in
+# those files. Users are asked to read the 3rd Party Licenses
+# referenced with those assets.
+#
+# Copyright (c) 2019 Government of Canada
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+import csv
+import logging
+
+from woudc_data_registry import config
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ReportWriter:
+    """
+    Manages accounting and file outputs during a processing run.
+    Generates several types of report files in the processing run's working
+    directory, which are for tracking warnings and errors in the inputs.
+    """
+
+    def __init__(self, root=None):
+        """
+        Initialize a new ReportWriter working in the directory <root>.
+
+        :param root: Path to the processing run's working directory.
+        """
+
+        self._working_directory = root
+        self._error_definitions = {}
+
+        self._report_batch = {
+            'Processing Status': '',
+            'Station Type': '',
+            'Station ID': '',
+            'Agency': '',
+            'Dataset': '',
+            'Data Level': '',
+            'Data Form': '',
+            'Filename': '',
+            'Line Number': [],
+            'Error Type': [],
+            'Error Code': [],
+            'Message': [],
+            'Incoming Path': '',
+            'Outgoing Path': '',
+            'URN': ''
+        }
+
+        self.read_error_definitions(config.WDR_ERROR_CONFIG)
+
+    def read_error_definitions(self, filepath):
+        """
+        Loads the error definitions found in <filepath> to apply those
+        rules to future error/warning determination.
+
+        :param filepath: Path to an error definition file.
+        """
+
+        with open(filepath) as error_definitions:
+            reader = csv.reader(error_definitions, escapechar='\\')
+            next(reader)  # Skip header line.
+
+            for row in reader:
+                error_code = int(row[0])
+                self._error_definitions[error_code] = row[1:3]
+
+    def _flush_report_batch(self):
+        """
+        Empties out the stored report batch in preparation for starting to
+        process a new file.
+        """
+
+        for field, column in self._report_batch.items():
+            if isinstance(column, str):
+                self._report_batch[field] = ''
+            else:
+                self._report_batch[field].clear()
+
+    def add_message(self, error_code, line=None, **kwargs):
+        """
+        Logs that an error of type <error_code> was found at line <line>
+        in an input file.
+
+        Returns two elements: the first is the warning/error message string,
+        and the second is False iff <error_code> matches an error severe
+        enough to cause a processing run to abort.
+
+        :param error_code: Numeric code of an error, as defined in the
+                           error definition file.
+        :param line: Line number where the error occurred, or None
+                     if not applicable.
+        :param kwargs: Keyword parameters to insert into the error message.
+        :returns: Error message, and False iff a severe error has occurred.
+        """
+
+        try:
+            error_class, message_template = self._error_definitions[error_code]
+            message = message_template.format(**kwargs)
+        except KeyError:
+            msg = 'Unrecognized error code {}'.format(error_code)
+            LOGGER.error(msg)
+            raise ValueError(msg)
+
+        self._report_batch['Line Number'].append(line)
+        self._report_batch['Error Code'].append(error_code)
+        self._report_batch['Error Type'].append(error_class)
+        self._report_batch['Message'].append(message)
+
+        severe = error_class != 'Warning'
+        return message, severe
+
+    def record_passing_file(self, filepath, extcsv, data_record):
+        """
+        Write out all warnings found while processing <filepath>, complete
+        with metadata from the source Extended CSV <extcsv> and the
+        generated data record <data_record>.
+
+        :param filepath: Path to an incoming data file.
+        :param extcsv: Extended CSV object generated from the incoming file.
+        :param data_record: Data record generated from the incoming file.
+        """
+
+        self._flush_report_batch()
+
+    def record_failing_file(self, filepath, extcsv=None, agency=None):
+        """
+        Write out all warnings and errors found while processing <filepath>,
+        complete with metadata from the source Extended CSV <extcsv>
+        if available. If <extcsv> is None, <agency> must be provided to
+        be able to label the file with its contributing agency.
+
+        If the file was able to be parsed, an Extended CSV object was created
+        that must be used to determine file metadata. If the file fails to be
+        parsed, that metadata will be unavailable and most fields will be
+        left blank.
+
+        :param filepath: Path to an incoming data file.
+        :param extcsv: Extended CSV object generated from the incoming file.
+        :param agency: Agency acronym responsible for the incoming file.
+        """
+
+        self._flush_report_batch()


### PR DESCRIPTION
Uses the errors.csv config file to control the responses to errors during processing. Uses the ReportWriter class to accomplish this, and lays out parts of that class that will generate run reports in the future.

Includes some cleanup as well, including removing the -f and -d flags on the `woudc-data-registry data verify/ingest` commands, and moving file detection and parsing responsibilities between processing.py and controller.py.