### PR TITLE
RFC3339 Date Formatting

### DIFF
--- a/woudc_data_registry/models.py
+++ b/woudc_data_registry/models.py
@@ -59,30 +59,14 @@ from sqlalchemy.orm import relationship
 
 from woudc_data_registry import config, registry
 from woudc_data_registry.search import SearchIndex, search
-from woudc_data_registry.util import point2geojsongeometry
+from woudc_data_registry.util import point2geojsongeometry, strftime_rfc3339
 
 base = declarative_base()
 
 LOGGER = logging.getLogger(__name__)
 
-RFC3339_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 WMO_REGION_ENUM = Enum('I', 'II', 'III', 'IV', 'V', 'VI', 'the Antarctic',
                        'International Waters', name='wmo_region_id')
-
-
-def strftime_rfc3339(datetimeobj=None):
-    """
-    Returns a version of <datetimeobj> as an RFC3339-formatted string
-    (YYYY-MM-DD'T'HH:MM:SS'Z').
-
-    :param datetimeobj: A datetime.datetime or datetime.date object.
-    :returns: A string (or None) version of <datetimeobj> in RFC3339 format.
-    """
-
-    if datetimeobj is None:
-        return None
-    else:
-        return datetimeobj.strftime(RFC3339_DATETIME_FORMAT)
 
 
 class Country(base):

--- a/woudc_data_registry/models.py
+++ b/woudc_data_registry/models.py
@@ -65,22 +65,24 @@ base = declarative_base()
 
 LOGGER = logging.getLogger(__name__)
 
+RFC3339_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 WMO_REGION_ENUM = Enum('I', 'II', 'III', 'IV', 'V', 'VI', 'the Antarctic',
                        'International Waters', name='wmo_region_id')
 
 
-def elasticise_datetime(dt):
+def strftime_rfc3339(datetimeobj=None):
     """
-    Returns a version of <dt> formatted for Elasticsearch indexing.
+    Returns a version of <datetimeobj> as an RFC3339-formatted string
+    (YYYY-MM-DD'T'HH:MM:SS'Z').
 
-    :param dt: A datetime.datetime or datetime.date object.
-    :returns: A string (or None) version of <dt> for Elasticsearch.
+    :param datetimeobj: A datetime.datetime or datetime.date object.
+    :returns: A string (or None) version of <datetimeobj> in RFC3339 format.
     """
 
-    if dt is None:
+    if datetimeobj is None:
         return None
     else:
-        return dt.strftime('%Y-%m-%dT%H:%M:%SZ')
+        return datetimeobj.strftime(RFC3339_DATETIME_FORMAT)
 
 
 class Country(base):
@@ -136,7 +138,7 @@ class Country(base):
                 'country_name_en': self.name_en,
                 'country_name_fr': self.name_fr,
                 'wmo_region_id': self.wmo_region_id,
-                'wmo_membership': elasticise_datetime(self.wmo_membership),
+                'wmo_membership': strftime_rfc3339(self.wmo_membership),
                 'regional_involvement': self.regional_involvement,
                 'link': self.link
             }
@@ -234,10 +236,10 @@ class Contributor(base):
                 'wmo_region_id': self.wmo_region_id,
                 'url': self.url,
                 'active': self.active,
-                'start_date': elasticise_datetime(self.start_date),
-                'end_date': elasticise_datetime(self.end_date),
+                'start_date': strftime_rfc3339(self.start_date),
+                'end_date': strftime_rfc3339(self.end_date),
                 'last_validated_datetime':
-                    elasticise_datetime(self.last_validated_datetime)
+                    strftime_rfc3339(self.last_validated_datetime)
             }
         }
 
@@ -366,8 +368,8 @@ class Instrument(base):
                 'name': self.name,
                 'model': self.model,
                 'serial': self.serial,
-                'start_date': elasticise_datetime(self.start_date),
-                'end_date': elasticise_datetime(self.end_date),
+                'start_date': strftime_rfc3339(self.start_date),
+                'end_date': strftime_rfc3339(self.end_date),
                 'waf_url': '/'.join([waf_basepath, dataset_folder,
                                      station_folder, instrument_folder])
             }
@@ -512,10 +514,10 @@ class Station(base):
                 'country_name_fr': self.country.name_fr,
                 'wmo_region_id': self.wmo_region_id,
                 'active': self.active,
-                'start_date': elasticise_datetime(self.start_date),
-                'end_date': elasticise_datetime(self.end_date),
+                'start_date': strftime_rfc3339(self.start_date),
+                'end_date': strftime_rfc3339(self.end_date),
                 'last_validated_datetime':
-                    elasticise_datetime(self.last_validated_datetime),
+                    strftime_rfc3339(self.last_validated_datetime),
                 'gaw_url': '{}/{}'.format(gaw_baseurl, gaw_pagename)
             }
         }
@@ -623,8 +625,8 @@ class Deployment(base):
                 'contributor_name': self.contributor.name,
                 'contributor_project': self.contributor.project_id,
                 'contributor_url': self.contributor.url,
-                'start_date': elasticise_datetime(self.start_date),
-                'end_date': elasticise_datetime(self.end_date)
+                'start_date': strftime_rfc3339(self.start_date),
+                'end_date': strftime_rfc3339(self.end_date)
             }
         }
 
@@ -881,7 +883,7 @@ class DataRecord(base):
                 'content_form': self.content_form,
 
                 'data_generation_date':
-                    elasticise_datetime(self.data_generation_date),
+                    strftime_rfc3339(self.data_generation_date),
                 'data_generation_agency': self.data_generation_agency,
                 'data_generation_version': self.data_generation_version,
                 'data_generation_scientific_authority': self.data_generation_scientific_authority,  # noqa
@@ -897,19 +899,17 @@ class DataRecord(base):
                 'instrument_number': self.instrument_number,
 
                 'timestamp_utcoffset': self.timestamp_utcoffset,
-                'timestamp_date': elasticise_datetime(self.timestamp_date),
+                'timestamp_date': strftime_rfc3339(self.timestamp_date),
                 'timestamp_time': None if self.timestamp_time is None \
                     else self.timestamp_time.isoformat(),
 
                 'published': self.published,
-                'received_datetime':
-                    elasticise_datetime(self.received_datetime),
-                'inserted_datetime':
-                    elasticise_datetime(self.inserted_datetime),
+                'received_datetime': strftime_rfc3339(self.received_datetime),
+                'inserted_datetime': strftime_rfc3339(self.inserted_datetime),
                 'processed_datetime':
-                    elasticise_datetime(self.processed_datetime),
+                    strftime_rfc3339(self.processed_datetime),
                 'published_datetime':
-                    elasticise_datetime(self.published_datetime),
+                    strftime_rfc3339(self.published_datetime),
 
                 'number_of_observations': self.number_of_observations,
 

--- a/woudc_data_registry/models.py
+++ b/woudc_data_registry/models.py
@@ -69,6 +69,20 @@ WMO_REGION_ENUM = Enum('I', 'II', 'III', 'IV', 'V', 'VI', 'the Antarctic',
                        'International Waters', name='wmo_region_id')
 
 
+def elasticise_datetime(dt):
+    """
+    Returns a version of <dt> formatted for Elasticsearch indexing.
+
+    :param dt: A datetime.datetime or datetime.date object.
+    :returns: A string (or None) version of <dt> for Elasticsearch.
+    """
+
+    if dt is None:
+        return None
+    else:
+        return dt.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+
 class Country(base):
     """
     Data Registry Country
@@ -122,7 +136,7 @@ class Country(base):
                 'country_name_en': self.name_en,
                 'country_name_fr': self.name_fr,
                 'wmo_region_id': self.wmo_region_id,
-                'wmo_membership': self.wmo_membership,
+                'wmo_membership': elasticise_datetime(self.wmo_membership),
                 'regional_involvement': self.regional_involvement,
                 'link': self.link
             }
@@ -220,9 +234,10 @@ class Contributor(base):
                 'wmo_region_id': self.wmo_region_id,
                 'url': self.url,
                 'active': self.active,
-                'start_date': self.start_date,
-                'end_date': self.end_date,
-                'last_validated_datetime': self.last_validated_datetime
+                'start_date': elasticise_datetime(self.start_date),
+                'end_date': elasticise_datetime(self.end_date),
+                'last_validated_datetime':
+                    elasticise_datetime(self.last_validated_datetime)
             }
         }
 
@@ -351,8 +366,8 @@ class Instrument(base):
                 'name': self.name,
                 'model': self.model,
                 'serial': self.serial,
-                'start_date': self.start_date,
-                'end_date': self.end_date,
+                'start_date': elasticise_datetime(self.start_date),
+                'end_date': elasticise_datetime(self.end_date),
                 'waf_url': '/'.join([waf_basepath, dataset_folder,
                                      station_folder, instrument_folder])
             }
@@ -497,9 +512,10 @@ class Station(base):
                 'country_name_fr': self.country.name_fr,
                 'wmo_region_id': self.wmo_region_id,
                 'active': self.active,
-                'start_date': self.start_date,
-                'end_date': self.end_date,
-                'last_validated_datetime': self.last_validated_datetime,
+                'start_date': elasticise_datetime(self.start_date),
+                'end_date': elasticise_datetime(self.end_date),
+                'last_validated_datetime':
+                    elasticise_datetime(self.last_validated_datetime),
                 'gaw_url': '{}/{}'.format(gaw_baseurl, gaw_pagename)
             }
         }
@@ -607,8 +623,8 @@ class Deployment(base):
                 'contributor_name': self.contributor.name,
                 'contributor_project': self.contributor.project_id,
                 'contributor_url': self.contributor.url,
-                'start_date': self.start_date,
-                'end_date': self.end_date
+                'start_date': elasticise_datetime(self.start_date),
+                'end_date': elasticise_datetime(self.end_date)
             }
         }
 
@@ -864,7 +880,8 @@ class DataRecord(base):
                 'content_level': self.content_level,
                 'content_form': self.content_form,
 
-                'data_generation_date': self.data_generation_date,
+                'data_generation_date':
+                    elasticise_datetime(self.data_generation_date),
                 'data_generation_agency': self.data_generation_agency,
                 'data_generation_version': self.data_generation_version,
                 'data_generation_scientific_authority': self.data_generation_scientific_authority,  # noqa
@@ -880,15 +897,19 @@ class DataRecord(base):
                 'instrument_number': self.instrument_number,
 
                 'timestamp_utcoffset': self.timestamp_utcoffset,
-                'timestamp_date': self.timestamp_date,
+                'timestamp_date': elasticise_datetime(self.timestamp_date),
                 'timestamp_time': None if self.timestamp_time is None \
                     else self.timestamp_time.isoformat(),
 
                 'published': self.published,
-                'received_datetime': self.received_datetime,
-                'inserted_datetime': self.inserted_datetime,
-                'processed_datetime': self.processed_datetime,
-                'published_datetime': self.published_datetime,
+                'received_datetime':
+                    elasticise_datetime(self.received_datetime),
+                'inserted_datetime':
+                    elasticise_datetime(self.inserted_datetime),
+                'processed_datetime':
+                    elasticise_datetime(self.processed_datetime),
+                'published_datetime':
+                    elasticise_datetime(self.published_datetime),
 
                 'number_of_observations': self.number_of_observations,
 

--- a/woudc_data_registry/search.py
+++ b/woudc_data_registry/search.py
@@ -54,12 +54,15 @@ from woudc_data_registry import config
 
 LOGGER = logging.getLogger(__name__)
 
+
 typedefs = {
     'keyword': {
         'type': 'keyword',
         'ignore_above': 256
     }
 }
+
+DATE_FORMAT = 'date_time_no_millis'
 
 MAPPINGS = {
     'projects': {
@@ -104,7 +107,8 @@ MAPPINGS = {
                 'fields': {'raw': typedefs['keyword']}
             },
             'wmo_membership': {
-                'type': 'date'
+                'type': 'date',
+                'format': DATE_FORMAT
             },
             'regional_involvement': {
                 'type': 'text',
@@ -155,13 +159,16 @@ MAPPINGS = {
                 'type': 'boolean'
             },
             'start_date': {
-                'type': 'date'
+                'type': 'date',
+                'format': DATE_FORMAT
             },
             'end_date': {
-                'type': 'date'
+                'type': 'date',
+                'format': DATE_FORMAT
             },
             'last_validated_datetime': {
-                'type': 'date'
+                'type': 'date',
+                'format': DATE_FORMAT
             }
         }
     },
@@ -200,13 +207,16 @@ MAPPINGS = {
                 'type': 'boolean'
             },
             'start_date': {
-                'type': 'date'
+                'type': 'date',
+                'format': DATE_FORMAT
             },
             'end_date': {
-                'type': 'date'
+                'type': 'date',
+                'format': DATE_FORMAT
             },
             'last_validated_datetime': {
-                'type': 'date'
+                'type': 'date',
+                'format': DATE_FORMAT
             },
             'gaw_url': {
                 'type': 'text',
@@ -250,10 +260,12 @@ MAPPINGS = {
                 'fields': {'raw': typedefs['keyword']}
             },
             'start_date': {
-                'type': 'date'
+                'type': 'date',
+                'format': DATE_FORMAT
             },
             'end_date': {
-                'type': 'date'
+                'type': 'date',
+                'format': DATE_FORMAT
             },
             'waf_url': {
                 'type': 'text',
@@ -305,10 +317,12 @@ MAPPINGS = {
                 'fields': {'raw': typedefs['keyword']}
             },
             'start_date': {
-                'type': 'date'
+                'type': 'date',
+                'format': DATE_FORMAT
             },
             'end_date': {
-                'type': 'date'
+                'type': 'date',
+                'format': DATE_FORMAT
             }
         }
     },
@@ -338,7 +352,8 @@ MAPPINGS = {
                 'fields': {'raw': typedefs['keyword']}
             },
             'data_generation_date': {
-                'type': 'date'
+                'type': 'date',
+                'format': DATE_FORMAT
             },
             'data_generation_version': {
                 'type': 'float'
@@ -384,7 +399,8 @@ MAPPINGS = {
                 'fields': {'raw': typedefs['keyword']}
             },
             'timestamp_date': {
-                'type': 'date'
+                'type': 'date',
+                'format': DATE_FORMAT
             },
             'timestamp_time': {
                 'type': 'text',
@@ -394,16 +410,20 @@ MAPPINGS = {
                 'type': 'boolean'
             },
             'received_datetime': {
-                'type': 'date'
+                'type': 'date',
+                'format': DATE_FORMAT
             },
             'inserted_datetime': {
-                'type': 'date'
+                'type': 'date',
+                'format': DATE_FORMAT
             },
             'processed_datetime': {
-                'type': 'date'
+                'type': 'date',
+                'format': DATE_FORMAT
             },
             'published_datetime': {
-                'type': 'date'
+                'type': 'date',
+                'format': DATE_FORMAT
             },
             'number_of_observations': {
                 'type': 'integer'

--- a/woudc_data_registry/util.py
+++ b/woudc_data_registry/util.py
@@ -49,6 +49,8 @@ import io
 
 LOGGER = logging.getLogger(__name__)
 
+RFC3339_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
+
 
 def point2geojsongeometry(x, y, z=None):
     """
@@ -137,6 +139,21 @@ def parse_integer_range(bounds_string):
         upper_bound = lower_bound
 
     return (lower_bound, upper_bound)
+
+
+def strftime_rfc3339(datetimeobj=None):
+    """
+    Returns a version of <datetimeobj> as an RFC3339-formatted string
+    (YYYY-MM-DD'T'HH:MM:SS'Z').
+
+    :param datetimeobj: A datetime.datetime or datetime.date object.
+    :returns: A string (or None) version of <datetimeobj> in RFC3339 format.
+    """
+
+    if datetimeobj is None:
+        return None
+    else:
+        return datetimeobj.strftime(RFC3339_DATETIME_FORMAT)
 
 
 def is_text_file(file_):


### PR DESCRIPTION
Updates the Elasticsearch mappings and the processing code to use RFC3339 formats (`YYYY-MM-DD'T'HH:MM:SS'Z'`) for the date fields in all indexes.