### PR TITLE
News Notifications

### DIFF
--- a/woudc_data_registry/__init__.py
+++ b/woudc_data_registry/__init__.py
@@ -51,6 +51,7 @@ from woudc_data_registry.epicentre.contributor import contributor
 from woudc_data_registry.epicentre.station import station
 from woudc_data_registry.epicentre.deployment import deployment
 from woudc_data_registry.epicentre.instrument import instrument
+from woudc_data_registry.epicentre.notification import notification
 from woudc_data_registry.models import admin
 from woudc_data_registry.log import setup_logger
 
@@ -73,3 +74,4 @@ cli.add_command(deployment)
 cli.add_command(instrument)
 cli.add_command(epicentre.dataset)
 cli.add_command(epicentre.project)
+cli.add_command(notification)

--- a/woudc_data_registry/epicentre/notification.py
+++ b/woudc_data_registry/epicentre/notification.py
@@ -1,0 +1,163 @@
+# =================================================================
+#
+# Terms and Conditions of Use
+#
+# Unless otherwise noted, computer program source code of this
+# distribution # is covered under Crown Copyright, Government of
+# Canada, and is distributed under the MIT License.
+#
+# The Canada wordmark and related graphics associated with this
+# distribution are protected under trademark law and copyright law.
+# No permission is granted to use them outside the parameters of
+# the Government of Canada's corporate identity program. For
+# more information, see
+# http://www.tbs-sct.gc.ca/fip-pcim/index-eng.asp
+#
+# Copyright title to all 3rd party software distributed with this
+# software is held by the respective copyright holders as noted in
+# those files. Users are asked to read the 3rd Party Licenses
+# referenced with those assets.
+#
+# Copyright (c) 2019 Government of Canada
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+from datetime import datetime
+import json
+import logging
+
+import click
+import yaml
+
+from woudc_data_registry.epicentre.metadata import (
+    add_metadata, get_metadata, update_metadata, delete_metadata)
+from woudc_data_registry.models import Notification
+from woudc_data_registry.util import json_serial
+
+from woudc_data_registry import config
+
+LOGGER = logging.getLogger(__name__)
+
+save_to_registry = config.EXTRAS['cli']['registry_enabled']
+save_to_index = config.EXTRAS['cli']['search_index_enabled']
+
+
+@click.group()
+def notification():
+    """News notification management"""
+    pass
+
+
+@click.command('list')
+@click.pass_context
+def list_(ctx):
+    """List all news notifications"""
+
+    for c in get_metadata(Notification):
+        click.echo('{} {}'.format(c.published, c.title_en))
+
+
+@click.command('show')
+@click.pass_context
+@click.argument('identifier', required=True)
+def show(ctx, identifier):
+    """Show news notification details"""
+
+    r = get_metadata(Notification, identifier)
+
+    if len(r) == 0:
+        click.echo('Notification not found')
+        return
+
+    click.echo(json.dumps(r[0].__geo_interface__, indent=4,
+                          default=json_serial))
+
+
+@click.command('add')
+@click.option('-id', '--identifier', 'identifier', required=False,
+              help='Forced news item identifier')
+@click.option('-p', '--path', required=True,
+              help='Path to YML file with news notification definition')
+@click.pass_context
+def add(ctx, identifier, path):
+    """Add a news notification"""
+
+    with open(path) as news_file:
+        notification = yaml.safe_load(news_file)
+        notification['published'] = datetime.now()
+
+        if identifier:
+            notification['identifier'] = identifier
+
+        added = add_metadata(Notification, notification,
+                             save_to_registry, save_to_index)
+        click.echo('Notification {} added'.format(added.notification_id))
+
+
+@click.command('update')
+@click.option('-id', '--identifier', 'identifier', required=False,
+              help='Forced news item identifier')
+@click.option('-p', '--path', required=True,
+              help='Path to YML file with news notification definition')
+@click.pass_context
+def update(ctx, identifier, path):
+    """Update news notification"""
+
+    with open(path) as news_file:
+        notification = yaml.safe_load(news_file)
+
+        if len(notification.keys()) == 1:
+            click.echo('No updates specified')
+            return
+
+        update_metadata(Notification, identifier, notification,
+                        save_to_registry, save_to_index)
+        click.echo('Notification {} updated'.format(identifier))
+
+
+@click.command('delete')
+@click.argument('identifier', required=True)
+@click.pass_context
+def delete(ctx, identifier):
+    """Delete a station"""
+
+    if len(get_metadata(Notification, identifier)) == 0:
+        click.echo('Station not found')
+        return
+
+    q = 'Are you sure you want to delete news notification {}?' \
+        .format(identifier)
+
+    if click.confirm(q):  # noqa
+        delete_metadata(Notification, identifier,
+                        save_to_registry, save_to_index)
+
+    click.echo('News notification {} deleted'.format(identifier))
+
+
+notification.add_command(list_)
+notification.add_command(show)
+notification.add_command(add)
+notification.add_command(update)
+notification.add_command(delete)

--- a/woudc_data_registry/models.py
+++ b/woudc_data_registry/models.py
@@ -1030,7 +1030,8 @@ class Notification(base):
     keywords_fr = Column(String, nullable=False)
 
     published_date = Column(Date, nullable=False)
-    removed = Column(Boolean, nullable=False, default=False)
+    banner = Column(Boolean, nullable=False, default=False)
+    visible = Column(Boolean, nullable=False, default=True)
 
     x = Column(Float, nullable=False)
     y = Column(Float, nullable=False)
@@ -1048,7 +1049,8 @@ class Notification(base):
         self.set_keywords_fr(dict_['keywords_fr'])
 
         self.published_date = dict_['published']
-        self.removed = dict_.get('removed', False)
+        self.banner = dict_.get('banner', False)
+        self.visible = dict_.get('visible', True)
 
         self.x = dict_['x']
         self.y = dict_['y']
@@ -1090,7 +1092,8 @@ class Notification(base):
                 'keywords_en': self.get_keywords_en(),
                 'keywords_fr': self.get_keywords_fr(),
                 'published_date': strftime_rfc3339(self.published_date),
-                'removed': self.removed
+                'banner': self.banner,
+                'visible': self.visible
             }
         }
 
@@ -1374,7 +1377,8 @@ def init(ctx, datadir, init_search_index):
         for row in reader:
             row['keywords_en'] = row['tags_en'].split(',')
             row['keywords_fr'] = row['tags_fr'].split(',')
-            row['removed'] = row['removed'] == 't'
+            row['banner'] = row['banner'] == 't'
+            row['visible'] = row['visible'] == 't'
 
             notification = Notification(row)
             notification_models.append(notification)

--- a/woudc_data_registry/models.py
+++ b/woudc_data_registry/models.py
@@ -1274,6 +1274,7 @@ def init(ctx, datadir, init_search_index):
     projects = os.path.join(datadir, 'projects.csv')
     instruments = os.path.join(datadir, 'instruments.csv')
     deployments = os.path.join(datadir, 'deployments.csv')
+    notifications = os.path.join(datadir, 'notifications.csv')
 
     registry_ = registry.Registry()
 
@@ -1286,6 +1287,7 @@ def init(ctx, datadir, init_search_index):
     instrument_models = []
     deployment_models = []
     contribution_models = []
+    notification_models = []
 
     click.echo('Loading WMO countries metadata')
     with open(wmo_countries) as jsonfile:
@@ -1366,6 +1368,17 @@ def init(ctx, datadir, init_search_index):
             instrument = Instrument(row)
             instrument_models.append(instrument)
 
+    click.echo('Loading news items')
+    with open(notifications) as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            row['keywords_en'] = row['tags_en'].split(',')
+            row['keywords_fr'] = row['tags_fr'].split(',')
+            row['removed'] = row['removed'] == 't'
+
+            notification = Notification(row)
+            notification_models.append(notification)
+
     click.echo('Storing projects in data registry')
     for model in project_models:
         registry_.save(model)
@@ -1389,6 +1402,9 @@ def init(ctx, datadir, init_search_index):
         registry_.save(model)
     click.echo('Storing instruments in data registry')
     for model in instrument_models:
+        registry_.save(model)
+    click.echo('Storing news items in data registry')
+    for model in notification_models:
         registry_.save(model)
 
     instrument_from_registry = registry_.query_full_index(Instrument)

--- a/woudc_data_registry/models.py
+++ b/woudc_data_registry/models.py
@@ -1089,7 +1089,7 @@ class Notification(base):
                 'description_fr': self.description_fr,
                 'keywords_en': self.get_keywords_en(),
                 'keywords_fr': self.get_keywords_fr(),
-                'published_date': self.published_date,
+                'published_date': strftime_rfc3339(self.published_date),
                 'removed': self.removed
             }
         }
@@ -1431,6 +1431,9 @@ def init(ctx, datadir, init_search_index):
             [model.__geo_interface__ for model in instrument_models]
         contribution_docs = \
             [model.__geo_interface__ for model in contribution_models]
+        notification_docs = \
+            [model.__geo_interface__ for model in notification_models]
+
         click.echo('Storing projects in search index')
         search_index.index(Project, project_docs)
         click.echo('Storing datasets in search index')
@@ -1447,6 +1450,8 @@ def init(ctx, datadir, init_search_index):
         search_index.index(Instrument, instrument_docs)
         click.echo('Storing contributions in search index')
         search_index.index(Contribution, contribution_docs)
+        click.echo('Storing news items in search index')
+        search_index.index(Notification, notification_docs)
 
 
 @click.command('sync')
@@ -1463,7 +1468,8 @@ def sync(ctx):
         Instrument,
         Deployment,
         DataRecord,
-        Contribution
+        Contribution,
+        Notification
     ]
 
     registry_ = registry.Registry()

--- a/woudc_data_registry/search.py
+++ b/woudc_data_registry/search.py
@@ -488,6 +488,42 @@ MAPPINGS = {
                 'type': 'date'
             }
         }
+    },
+    'notifications': {
+        'index': 'notification',
+        'properties': {
+            'title_en': {
+                'type': 'text',
+                'fields': {'raw': typedefs['keyword']}
+            },
+            'title_fr': {
+                'type': 'text',
+                'fields': {'raw': typedefs['keyword']}
+            },
+            'description_en': {
+                'type': 'text',
+                'fields': {'raw': typedefs['keyword']}
+            },
+            'description_fr': {
+                'type': 'text',
+                'fields': {'raw': typedefs['keyword']}
+            },
+            'keywords_en': {
+                'type': 'text',
+                'fields': {'raw': typedefs['keyword']}
+            },
+            'keywords_fr': {
+                'type': 'text',
+                'fields': {'raw': typedefs['keyword']}
+            },
+            'published_date': {
+                'type': 'date',
+                'format': DATE_FORMAT
+            },
+            'removed': {
+                'type': 'boolean'
+            },
+        }
     }
 }
 
@@ -655,18 +691,18 @@ class SearchIndex(object):
                                    body=wrapper)
         else:
             # Index/update multiple documents using bulk API.
-            wrapper = [{
+            wrapper = ({
                 '_op_type': 'update',
                 '_index': index_name,
                 '_type': '_doc',
                 '_id': document['id'],
                 'doc': document,
                 'doc_as_upsert': True
-            } for document in target]
+            } for document in target)
 
-            LOGGER.debug('Indexing {} documents into {}'
-                         .format(len(target), index_name))
-            helpers.bulk(self.connection, wrapper)
+            LOGGER.debug('Indexing documents into {}'.format(index_name))
+            helpers.bulk(self.connection, wrapper,
+                         raise_on_error=False, raise_on_exception=False)
 
         return True
 
@@ -709,14 +745,15 @@ class SearchIndex(object):
                 raise SearchIndexError(msg)
         else:
             # Delete multiple documents using bulk API.
-            wrapper = [{
+            wrapper = ({
                 '_op_type': 'delete',
                 '_index': index_name,
                 '_type': '_doc',
                 '_id': document['id']
-            } for document in target]
+            } for document in target)
 
-            helpers.bulk(self.connection, wrapper)
+            helpers.bulk(self.connection, wrapper,
+                         raise_on_error=False, raise_on_exception=False)
 
         return True
 

--- a/woudc_data_registry/search.py
+++ b/woudc_data_registry/search.py
@@ -520,9 +520,12 @@ MAPPINGS = {
                 'type': 'date',
                 'format': DATE_FORMAT
             },
-            'removed': {
+            'banner': {
                 'type': 'boolean'
             },
+            'visible': {
+                'type': 'boolean'
+            }
         }
     }
 }


### PR DESCRIPTION
Create a model for news notifications and adds tables and indexes in the Data Registry and Search Index. Tweaks the `init` and `sync` commands to populate these new places.

Possibly we should add a `epicenter/notifications.py` which has a CLI for adding news items?