### PR TITLE
Move logger statement below object save

### DIFF
--- a/woudc_data_registry/models.py
+++ b/woudc_data_registry/models.py
@@ -1193,6 +1193,7 @@ class PeerDataRecord(base):
         self.pi_name = dict_.get('pi_name')
         self.pi_email = dict_.get('pi_email')
         self.url = dict_['url']
+        
         self._name = dict_['station_name']
 
         try:

--- a/woudc_data_registry/models.py
+++ b/woudc_data_registry/models.py
@@ -1193,7 +1193,6 @@ class PeerDataRecord(base):
         self.pi_name = dict_.get('pi_name')
         self.pi_email = dict_.get('pi_email')
         self.url = dict_['url']
-
         self._name = dict_['station_name']
 
         try:
@@ -1218,10 +1217,11 @@ class PeerDataRecord(base):
     @property
     def __geo_interface__(self):
         return {
-            'id': self.url,
+            'id': ''.join(self.url.split('%')[5:10]),
             'type': 'Feature',
             'geometry': point2geojsongeometry(self.x, self.y, self.z),
             'properties': {
+                'identifier': ''.join(self.url.split('%')[5:10]),
                 'source': self.source,
                 'measurement': self.measurement,
                 'station_id': self.station_id,

--- a/woudc_data_registry/models.py
+++ b/woudc_data_registry/models.py
@@ -1193,7 +1193,7 @@ class PeerDataRecord(base):
         self.pi_name = dict_.get('pi_name')
         self.pi_email = dict_.get('pi_email')
         self.url = dict_['url']
-        
+
         self._name = dict_['station_name']
 
         try:

--- a/woudc_data_registry/registry.py
+++ b/woudc_data_registry/registry.py
@@ -197,13 +197,14 @@ class Registry(object):
                                 ' skipping'.format(obj.__tablename__))
                     return
 
-            LOGGER.debug('Saving {}'.format(obj))
             try:
                 self.session.commit()
             except SQLAlchemyError as err:
                 LOGGER.error('Failed to persist {} due to: {}'
                              .format(obj, err))
                 self.session.rollback()
+
+            LOGGER.debug('Saving {}'.format(obj))
         except DataError as err:
             LOGGER.error('Failed to save to registry: {}'.format(err))
             self.session.rollback()


### PR DESCRIPTION
Ensure all dependencies are initialized prior to object reference. Also omit slashes in peer_data_records identifier for woudc-api compatibility.