### PR TITLE
Make contributor_url a virtual property for PeerDataRecords

### DIFF
--- a/woudc_data_registry/models.py
+++ b/woudc_data_registry/models.py
@@ -1250,6 +1250,11 @@ class PeerDataRecord(base):
             return self.station_name.name
 
     @property
+    def contributor_url(self):
+        if self.contributor is not None:
+            return self.contributor.url
+
+    @property
     def __geo_interface__(self):
         gaw_baseurl = 'https://gawsis.meteoswiss.ch/GAWSIS/index.html#' \
             '/search/station/stationReportDetails'
@@ -1270,7 +1275,7 @@ class PeerDataRecord(base):
                 'gaw_id': self.gaw_id,
                 'contributor_acronym': self.contributor_acronym,
                 'contributor_url':
-                self.contributor.url,
+                self.contributor_url,
                 'country_id': self.country_id,
                 'instrument_type': self.instrument_type,
                 'level': self.level,


### PR DESCRIPTION
Make contributor_url a virtual property on ES for PeerDataRecords, so that contributor_acronym may be null without errors being raised. 