### PR TITLE
Change content_category to keyword

### DIFF
--- a/woudc_data_registry/search.py
+++ b/woudc_data_registry/search.py
@@ -342,7 +342,7 @@ MAPPINGS = {
                 'fields': {'raw': typedefs['keyword']}
             },
             'content_category': {
-                'type': 'text',
+                'type': 'keyword',
                 'fields': {'raw': typedefs['keyword']}
             },
             'content_form': {


### PR DESCRIPTION
Change content_category to be a keyword, since as a text type, queries with "Multi-band" or "Broad-band"  as an input to content_category would yield results from both data types.