### PR TITLE
Change OzoneSonde product sync & sync capacities

### DIFF
--- a/woudc_data_registry/models.py
+++ b/woudc_data_registry/models.py
@@ -2281,10 +2281,10 @@ def product_sync(ctx):
 
             registry_contents.append(obj)
 
-            if product == 'OzoneSonde':
-                capacity = 50
+            if plural_caps == 'Ozonesonde':
+                capacity = 45
             else:
-                capacity = 500000
+                capacity = 100000
 
             if len(registry_contents) > capacity:
                 registry_docs = [item.__geo_interface__


### PR DESCRIPTION
Decrease chunk sizes of product syncs (elasticsearch indexing processes were being killed with larger chunk sizes)  

(also corrected a typo in the OzoneSonde product sync)