### PR TITLE
Add discovery_metadata table to PSQL and index on ES.

### DIFF
--- a/data/woudc.skos.yaml
+++ b/data/woudc.skos.yaml
@@ -1,0 +1,819 @@
+# this is a YAML-based SKOS implementation of the WOUDC taxonomy
+# as per
+# http://ontappsp.ontario.int.ec.gc.ca/sites/DMFTeam/DMFDocuments/WMO-WOUDC/Renewal/02-design/woudc_file_structure.jpg
+
+# data taxonomy
+data:
+    data_categories:
+        - ozone:
+            doi: 10.14287/10000001
+            label_en: Ozone
+            attribution_title: WMO/GAW Ozone Monitoring Community, World Meteorological Organization-Global Atmosphere Watch Program (WMO-GAW)/World Ozone and Ultraviolet Radiation Data Centre (WOUDC)
+            datasetcollections:
+                - total-column-ozone:
+                    label_en: Total Column Ozone
+                    label_fr: Ozone total de la colonne
+                    description_en: Total column ozone is a measurement of the total amount of ozone in the atmosphere in any given column from the surface to the edge of the atmosphere. It is usually measured in Dobson Units (DU). This dataset comprises of column ozone from the Dobson, Brewer, SAOZ, Filter, and other networks.
+                    description_fr: L'ozone total de la colonne est une mesure de la quantité totale de l'ozone dans l'atmosphère dans une colonne donnée de la couche la plus basse à la couche la plus haute de l'atmosphère. Elle est habituellement mesurée en unités Dobson. Cet ensemble de données porte sur la colonne d'ozone provenant de réseaux de stations à spectrophotomètres Dobson, Brewer, SAOZ, à filtres et autres réseaux.
+                    keywords_en:
+                        - dobson
+                        - total column ozone
+                        - total
+                        - brewer
+                        - saoz
+                        - filter
+                        - hoelper
+                        - vassey
+                        - pion
+                        - microtops
+                        - column
+                    keywords_fr:
+                        - dobson
+                        - ozone total de la colonne
+                        - total
+                        - brewer
+                        - saoz
+                        - filtres
+                        - hoelper
+                        - vassey
+                        - pion
+                        - microtops
+                        - colonne
+                    extent:
+                        time: 1924-08-18/now
+                    datasets:
+                        - TotalOzoneObs:
+                            doi: 10.14287/10000003
+                            label_en: Total Ozone - hourly observations
+                            label_fr: Ozone total – observations horaires
+                            description_en: A measurement of the total amount of atmospheric ozone in a given column from the surface to the edge of the atmosphere. Ground based instruments such as spectrophotometers and ozonemeters are used to measure results hourly.
+                            description_fr: Mesure de la quantité totale de l'ozone dans l'atmosphère dans une colonne donnée de la couche la plus basse à la couche la plus haute de l'atmosphère. Des instruments au sol, comme les spectrophotomètres et les ozonomètres, sont utilisés pour mesurer les résultats toutes les heures.
+                            keywords_en:
+                                - total
+                                - ozone
+                                - observations
+                                - obs
+                                - level 1.0
+                                - column
+                                - dobson
+                                - obs
+                            keywords_fr:
+                                - total
+                                - ozone
+                                - observations
+                                - obs
+                                - niveau 1.0
+                                - colonne
+                                - dobson
+                                - obs
+                            extent:
+                                time: 1984-05-03/now
+                            waf_dir: TotalOzoneObs_1.0_1
+                            levels:
+                                - 1.0:
+                                    label_en: Level 1.0
+                                    networks:
+                                        - dobson: &id_dobson
+                                            label_en: Dobson
+                                            instruments:
+                                                - dobson:
+                                                    label_en: Dobson
+                                        - brewer: &id_brewer
+                                            label_en: Brewer
+                                            instruments:
+                                                - brewer: &id_brewer_instrument
+                                                    label_en: Brewer
+                        - TotalOzone:
+                            doi: 10.14287/10000004
+                            label_en: Total Ozone - daily observations
+                            label_fr: Ozone total - observations quotidiennes
+                            description_en: A measurement of the total amount of atmospheric ozone in a given column from the surface to the edge of the atmosphere. Ground based instruments such as spectrophotometers and ozonemeters are used to measure results daily.
+                            description_fr: Mesure de la quantité totale de l'ozone dans l'atmosphère dans une colonne donnée de la couche la plus basse à la couche la plus haute de l'atmosphère. Des instruments au sol, comme les spectrophotomètres et les ozonomètres, sont utilisés pour mesurer les résultats une fois par jour.
+                            keywords_en:
+                                - total
+                                - ozone
+                                - level 1.0
+                                - column
+                                - dobson
+                                - brewer
+                                - saoz
+                            keywords_fr:
+                                - total
+                                - ozone
+                                - niveau 1.0
+                                - colonne
+                                - dobson
+                                - brewer
+                                - saoz
+                            extent:
+                                time: 1924-08-18/now 
+                            waf_dir: TotalOzone_1.0_1
+                            levels:
+                                - 1.0:
+                                    label_en: Level 1.0
+                                    networks:
+                                        - dobson: *id_dobson
+                                        - brewer: *id_brewer
+                                        - other:
+                                            label_en: Other
+                                            instruments:
+                                                - vassey:
+                                                    label_en: Vassey
+                                                - pion: &id_pion_instrument
+                                                    label_en: Pion
+                                                - microtops:
+                                                    label_en: Microtops
+                                                - spectral:
+                                                    label_en: Spectral
+                                                - hoelper:
+                                                    label_en: Hoelper
+                                                - specialo3:
+                                                    label: SpecialO3
+                                        - saoz:
+                                            label_en: SAOZ
+                                            instruments:
+                                                - saoz:
+                                                    label_en: SAOZ
+                                                - filter:
+                                                    label_en: Filter
+                                - 2.0:
+                                    label_en: Level 2.0
+                                    networks:
+                                        - brewer: *id_brewer     
+                - vertical-ozone-profile:
+                    label_en: Vertical Ozone Profile
+                    label_fr: Courbe de répartition verticale de l'ozone
+                    description_en: Vertical ozone profiles show the distribution/density of ozone in the atmosphere from roughly 0-50km from the surface. Data in this dataset is pulled from the Dobson, Lidar, Brewer, and Ozonesonde networks. This includes Umkehr level 1 and 2 measurements.
+                    description_fr: Les courbes de répartition verticale de l'ozone indiquent la répartition et la densité de l'ozone dans l'atmosphère entre la surface de la Terre et une altitude de 50 km environ. Les données contenues dans cet ensemble de données proviennent des réseaux Dobson, Lidar, Brewer et Ozonesonde. Cela comprend les mesures Umkehr de niveaux 1 et 2.
+                    keywords_en:
+                        - vertical ozone profile
+                        - vertical ozone
+                        - ozone
+                        - dobson
+                        - lidar
+                        - brewer
+                        - ozonesonde
+                        - umkehr
+                        - level 1
+                        - level 2
+                        - distribution
+                    keywords_fr:
+                        - courbe de répartition verticale de l'ozone
+                        - courbe verticale de l'ozone
+                        - ozone
+                        - dobson
+                        - lidar
+                        - brewer
+                        - sonde pour l'ozone
+                        - umkehr
+                        - niveau 1
+                        - niveau 2
+                        - distribution
+                    extent:
+                        time: 1951-10-21/now
+                    datasets:
+                        - UmkehrN14:
+                            label_en: UmkehrN14
+                            label_fr: UmkehrN14
+                            levels:
+                                - 1.0:
+                                    doi: 10.14287/10000005
+                                    label_en: Level 1.0
+                                    label_fr: Niveau 1.0
+                                    description_en: Umkehr measurements are ozone profiles compiled using 14 N-values, measured with ultraviolet spectrophotometers of the ratio of zenith sky light intensities of two wavelengths in the solar ultraviolet range when the sun is near the horizon. Level 1 is raw Umkehr data which contains data collected at 14 zenith angles.
+                                    description_fr: Les mesures Umkehr sont des profils d'ozone dressés en appliquant 14 valeurs N, mesurés au moyen de spectrophotomètres à ultraviolet du ratio des intensités lumineuses du ciel au zénith de deux longueurs d'onde dans la plage des ultraviolets solaires lorsque le soleil est près de l'horizon. Le niveau 1 correspond aux données Umkehr brutes qui contiennent les données recueillies à 14 angles zénithaux.
+                                    keywords_en:
+                                        - umkehr
+                                        - umkehrN14
+                                        - "14"
+                                        - solar
+                                        - zenith
+                                        - angle
+                                        - level 1.0
+                                    keywords_fr:
+                                        - umkehr
+                                        - umkehr N14
+                                        - "14"
+                                        - solaire
+                                        - zénith
+                                        - angle
+                                        - niveau 1.0
+                                    extent:
+                                        time: 1951-10-21/now
+                                    waf_dir: UmkehrN14_1.0_1
+                                    networks:
+                                        - dobson: *id_dobson
+                                        - brewer: *id_brewer
+                                - 2.0:
+                                    doi: 10.14287/10000006
+                                    label_en: Level 2.0
+                                    label_fr: Niveau 2.0
+                                    description_en: Umkehr measurements are ozone profiles compiled using 14 N-values, measured with ultraviolet spectrophotometers of the ratio of zenith sky light intensities of two wavelengths in the solar ultraviolet range when the sun is near the horizon. Ozone profiles are derived from these measurements.
+                                    description_fr: Les mesures Umkehr sont des profils d'ozone dressés en appliquant 14 valeurs N, mesurées au moyen de spectrophotomètres à ultraviolet du ratio des intensités lumineuses du ciel au zénith de deux longueurs d'onde dans la plage des ultraviolets solaires lorsque le soleil est près de l'horizon. Les profils d'ozone sont dérivés de ces mesures.
+                                    keywords_en:
+                                        - umkehr
+                                        - umkehrN14
+                                        - "14"
+                                        - solar
+                                        - zenith
+                                        - angle
+                                        - level 2.0
+                                    keywords_fr:
+                                        - umkehr
+                                        - umkehr N14
+                                        - "14"
+                                        - solaire
+                                        - zénith
+                                        - angle
+                                        - niveau 2.0
+                                    extent:
+                                        time: 1951-10-21/now
+                                    waf_dir: UmkehrN14_2.0_1
+                                    networks:
+                                        - dobson: *id_dobson
+                                        - brewer: *id_brewer
+                        - Lidar:
+                            doi: 10.14287/10000007
+                            label_en: Lidar
+                            label_fr: Lidar
+                            description_en: Temperature and ozone density data above about 25km is lidar derived. Lidar is a technology that measures distances by laser targeting to create density maps. Temperature and density below 20-25km (maximum sonde height) is that given by the nearest in time Buffalo radiosonde. Between the maximum sonde height up to around 25km the temperature and density is estimated by interpolating between the sonde and lidar values.
+                            description_fr: Les données sur la température et sur la densité de l'ozone au-dessus de 25 km environ sont dérivées de lidar. La technologie du lidar permet de mesurer les distances en désignant des objectifs par laser et de générer des cartes de densité. La température et la densité sous les 20 à 25 km (altitude maximale que peut atteindre une sonde) correspondent à celles données par la radiosonde de Buffalo la plus près, chronologiquement parlant. Entre l'altitude maximale atteinte par la sonde et une altitude d'environ 25 km, la température et la densité s'obtiennent en interpolant les valeurs de la sonde et du lidar.
+                            keywords_en:
+                                - lidar
+                                - lidar (level 1.0)
+                                - ozone
+                                - atmospheric
+                                - level
+                                - 25km
+                                - ozone density
+                            keywords_fr:
+                                - lidar
+                                - lidar (niveau 1.0)
+                                - ozone
+                                - atmosphérique
+                                - niveau
+                                - 25km
+                                - densité de l'ozone
+                            extent:
+                                time: 1991-03-14/now
+                            waf_dir: Lidar_1.0_1
+                            levels:
+                                - 1.0:
+                                    label_en: Level 1.0
+                                    networks:
+                                        - lidar:
+                                            label_en: Lidar
+                                            instruments:
+                                                - dial:
+                                                    label_en: Dial
+                        - OzoneSonde:
+                            doi: 10.14287/10000008
+                            label_en: Ozonesonde
+                            label_fr: Sonde pour l'ozone
+                            description_en: Vertically profiled ozone levels in the atmosphere defined by ballone-borne ozone instruments. Ozonesondes are lightweight, ozone-measuring modules suitable for launching on small balloons. These balloons ascend to the stratospheric and lower tropospheric layers of the atmosphere.
+                            description_fr: Des instruments emportés par ballon de détection de l'ozone dans l'atmosphère établissent des profils verticaux des niveaux d'ozone. Les sondes pour l'ozone sont des modules légers de mesure de l'ozone capables d'être lancés à l'aide de petits ballons. Ces ballons s'élèvent dans la stratosphère et les couches de la basse troposphère de l'atmosphère.
+                            keywords_en:
+                                - ozone
+                                - ozonesonde
+                                - level 1.0
+                            keywords_fr:
+                                - ozone
+                                - sonde pour l'ozone
+                                - niveau 1.0
+                            extent:
+                                time: 1962-02-19/now
+                            waf_dir: OzoneSonde_1.0_1
+                            levels:
+                                - 1.0:
+                                    label_en: Level 1.0
+                                    networks:
+                                        - ozonesonde:
+                                            label_en: Ozonesonde
+                                            instruments:
+                                                - carbon-iodine:
+                                                    label_en: Carbon-Iodine
+                                                - indian-sonde:
+                                                    label_en: Indian-Sonde
+                                                - brewer-mast:
+                                                    label_en: Brewer Mast
+                                                - ecc:
+                                                    label_en: ECC
+                                                - regener:
+                                                    label_en: Regener
+                                                - undefined-sondes:
+                                                    label_en: Undefined Sondes
+                                                - pion: *id_pion_instrument
+                                                - brewer-gdr:
+                                                    label_en: Brewer-GDR
+                        - RocketSonde:
+                            doi: 10.14287/10000009
+                            label_en: Rocketsonde
+                            label_fr: Sonde pour la fusée
+                            description_en: ROCOZ data campaigns designed to survey latitude and seasonal changes in ozone densities in the stratosphere and lower mesosphere.  Further information can be found at https://woudc.org/archive/Archive-NewFormat/RocketSonde_1.0_1/DSS_ROCOZ_Ozonesondes.pdf
+                            description_fr: campagnes de données ROCOZ conçus pour étudier la latitude et les changements saisonniers dans les densités d'ozone dans la stratosphère et la mésosphère inférieure. Plus d'informations peuvent être trouvées à https://woudc.org/archive/Archive-NewFormat/RocketSonde_1.0_1/DSS_ROCOZ_Ozonesondes.pdf
+                            keywords_en:
+                                - ozone
+                                - rocketsonde
+                                - Super Loki
+                                - arcas
+                                - synoptic
+                                - level 1.0
+                            keywords_fr:
+                                - ozone
+                                - sonde pour la fusée
+                                - Super Loki
+                                - arcas
+                                - synoptique
+                                - niveau 1.0
+                            extent:
+                                time: 1965-03-07/1994-07-06
+                            waf_dir: RocketSonde_1.0_1
+                            levels:
+                                - 1.0:
+                                    label_en: Level 1.0
+                                    networks:
+                                        - rocoz:
+                                            label_en: Rocketsonde
+                                            instruments:
+                                                - rocoz:
+                                                    label_en: ROCOZ
+        - uv-radiation:
+            doi: 10.14287/10000002
+            label_en: Ultraviolet Radiation
+            attribution_title: WMO/GAW UV Radiation Monitoring Community, World Meteorological Organization-Global Atmosphere Watch Program (WMO-GAW)/World Ozone and Ultraviolet Radiation Data Centre (WOUDC)
+            datasetcollections:
+                - uv-irradiance:
+                    label_en: UV Irradiance
+                    label_fr: Irradiance des UV
+                    description_en: "The UV Irradiance dataset collection contains 3 different datasets and networks for UV measurements: Multi-band, Spectral, and Broadband. All three are level 1 data measured as a function of time and wavelength, time alone, or time and direction."
+                    description_fr: "La collection des ensembles de données sur l'irradiance des UV renferme 3 ensembles de données et réseaux distincts pour les mesures d'UV : multibande, spectrale et bande large. Tous les trois sont des données de niveau 1 mesurées comme une fonction du temps et de la longueur d'onde, du temps uniquement, ou du temps et de la direction."
+                    keywords_en:
+                        - uv
+                        - irradiance
+                        - multiband
+                        - spectral
+                        - broadband
+                        - multi-band
+                        - broad-band
+                        - kipp zonen
+                        - biometer
+                    keywords_fr:
+                        - uv
+                        - irradiance
+                        - multibande
+                        - spectral
+                        - bande large
+                        - multibande
+                        - kipp et zonen
+                        - biomètre
+                    extent:
+                        time: 1988-11-18/now
+                    datasets:
+                        - Multi-band:
+                            doi: 10.14287/10000010
+                            label_en: Multiband
+                            label_fr: Multibande
+                            description_en: Measurements include diffuse, spectral and total global radiation with several discrete, pass-band filters. Observations are made using various models of radiometers which compute direct irradiance with a nominal spectral resolution of 2-10nm at FWHM (Full width at half maximum).
+                            description_fr: Les mesures comprennent le rayonnement global diffus, spectral et total au moyen de plusieurs filtres passe-bande discrets. Les observations se font à l'aide de différents modèles de radiomètres qui calculent l'irradiation directe à une résolution spectrale nominale de 2 à 10 nm à la LTMH (largeur totale à mi-hauteur).
+                            keywords_en:
+                                - uv-a
+                                - uv-b
+                                - uv
+                                - radiation
+                                - multi-band
+                                - level 1.0
+                                - fwhm
+                                - filter
+                            keywords_fr:
+                                - uv-a
+                                - uv-b
+                                - uv
+                                - rayonnement
+                                - multibande
+                                - niveau 1.0
+                                - ltmh
+                                - filtre
+                            extent:
+                                time: 1997-05-27/now
+                            waf_dir: Multi-band_1.0_1
+                            levels:
+                                - 1.0:
+                                    label_en: Level 1.0
+                                    networks:
+                                        - multiband:
+                                            label_en: Multi-band
+                                            instruments:
+                                                - biospherical: &id_biospherical
+                                                    label_en: Biospherical
+                                                - yankee: &id_yankee
+                                                    label_en: Yankee
+                        - Spectral:
+                            doi: 10.14287/10000011
+                            label_en: Spectral
+                            label_fr: Spectral
+                            description_en: Similar to broad-band, Spectral measurements involves UV radiation measured with several discrete, pass-band filters with nominal spectral resolution of 2-10nm at FWHM (Full width at half maximum)
+                            description_fr: Tout comme la bande large, les mesures spectrales portent entre autres sur le rayonnement UV mesuré au moyen de plusieurs filtres passe-bande discrets à une résolution spectrale nominale de 2 à 10 nm à LTMH (largeur totale à mi-hauteur).
+                            keywords_en:
+                                - uv-a
+                                - uv-b
+                                - uv
+                                - radiation
+                                - multi-band
+                                - level 1.0
+                                - fwhm
+                                - filter
+                            keywords_fr:
+                                - uv-a
+                                - uv-b
+                                - uv
+                                - rayonnement
+                                - multibande
+                                - niveau 1.0
+                                - ltmh
+                                - filtre
+                            extent:
+                                time: 1988-11-18/now
+                            waf_dir: Spectral_1.0_1
+                            levels:
+                                - 1.0:
+                                    label_en: Level 1.0
+                                    networks:
+                                        - spectral:
+                                            label_en: Spectral
+                                            instruments:
+                                                - bentham:
+                                                    label_en: Bentham
+                                                - optronics:
+                                                    label_en: Optronics
+                                                - brewer: *id_brewer_instrument
+                                                - biospherical: *id_biospherical
+                                - 2.0:
+                                    label_en: Level 2.0
+                                    networks:
+                                        - spectral:
+                                            label_en: Spectral
+                                            instruments:
+                                                - bentham:
+                                                    label_en: Bentham
+                        - Broad-band:
+                            doi: 10.14287/10000012
+                            label_en: Broadband
+                            label_fr: Bande large
+                            description_en: Measurements of ultraviolet-A (UV-A), UV-B radiation and erythemally weighted UV radiation. The measurement technique utilizes colored glass optical filters to block the Sun’s visible spectra and a UV sensitive fluorescent phosphor to convert the UV light into visible light, which is then measured by a solid-state photodetector.
+                            description_fr: Mesures du rayonnement ultraviolet-A (UV-A), du rayonnement ultraviolet-B (UV-B) et du rayonnement des UV érythématogènes. La technique de mesure consiste en une combinaison de filtres optiques de verre de couleur pour bloquer les spectres visibles du soleil et d'une couche de phosphore fluorescent, sensible aux UV, pour convertir les UV-B en lumière visible, puis à mesurer celle-ci au moyen d'un détecteur photo-électrique à semi-conducteurs.
+                            keywords_en:
+                                - uv-a
+                                - uv-b
+                                - uv
+                                - radiation
+                                - broad-band
+                                - level 1.0
+                            keywords_fr:
+                                - uv-a
+                                - uv-b
+                                - uv
+                                - rayonnement
+                                - bande large
+                                - niveau 1.0
+                            extent:
+                                time: 1997-01-09/now
+                            waf_dir: Broad-band_1.0_1
+                            levels:
+                                - 1.0:
+                                    label_en: Level 1.0
+                                    networks:
+                                        - broadband:
+                                            label_en: Broad-band
+                                            instruments:
+                                                - yankee: *id_yankee
+                                                - kipp-zonen:
+                                                    label_en: Kipp Zonen
+                                                - uv-biometer:
+                                                    label_en: UV-Biometer
+                                                - uva-detector:
+                                                    label_en: UVA-Detector
+                                                - uva-radiometer:
+                                                    label_en: UVA-Radiometer
+                                - 2.0:
+                                    label_en: Level 2.0
+                                    networks:
+                                        - broadband:
+                                            label_en: Broad-band
+                                            instruments:
+                                                - kipp-zonen:
+                                                    label_en: Kipp Zonen
+                        - uv_index_hourly:
+                            doi: 10.14287/10000013
+                            id: data_payload_id
+                            label_en: UV Index (hourly maximum)
+                            label_fr: Indice UV (maximum horaire)
+                            description_en: Developed by Canadian scientists in 1992, the ultraviolet index or UV index measures the strength of sunburn-producing ultraviolet radiation at a given location and time.  The index values are calculated from measurements made by ground-based spectometers, broad-band filter radiometer and multi-filter radiometer.  UV index values can also be retrieved from satellite measurements of atmospheric ozone and cloud cover.  The UV index is measured on a linear scale with higher values indicative of greater risk of sunburn on human skin.  Mean noontime UV index values in summer range from 1 in the Arctic to about 12 over the subtropical latitudes.  It can be as high as 26 over higher elevations in the tropics.  Factors affecting the UV index are sun elevation, total amount of ozone in the atmosphere, cloud cover, reflection from snow cover and local pollution.  Forecasts of UV index are now routinely made by various meteorological centres, and adopted as a standard indicator of UV radiation by the World Meteorological Organization and the World Health Organization.
+                            description_fr: Mis au point par des scientifiques canadiens en 1992, l’indice ultraviolet, ou indice UV, mesure l’intensité du rayonnement ultraviolet pouvant causer des coups de soleil à un endroit précis et à une heure donnée.  Les valeurs de l’indice sont calculées d’après les mesures effectuées par des spectromètres au sol, un radiomètre à filtre à bande large et un radiomètre multifiltre.  Les valeurs de l’indice UV peuvent également être tirées des mesures satellitaires de l’ozone atmosphérique et de la couverture nuageuse.  L’indice UV est mesuré sur une échelle linéaire dont les valeurs les plus élevées indiquent un risque accru de coup de soleil sur la peau humaine.  Les valeurs moyennes de l’indice UV à midi, en été, sont comprises entre 1 dans l’Arctique et près de 12 à des latitudes subtropicales.  Cet indice peut monter jusqu’à 26 dans des zones de haute altitude sous les tropiques.  Les facteurs influant sur l’indice UV sont la hauteur du soleil, la quantité totale d’ozone dans l’atmosphère, la couverture nuageuse, la réflexion produite par la couverture de neige et la pollution locale.  Les prévisions de l’indice UV sont maintenant couramment effectuées par les divers centres météorologiques et ont été adoptées comme indicateur standard du rayonnement UV par l’Organisation météorologique mondiale et l’Organisation mondiale de la santé.
+                            keywords_en:
+                                - ultraviolet radiation
+                                - spectral
+                                - broadband
+                                - multiband
+                                - solar zenith angle
+                                - sunburn
+                            keywords_fr:
+                                - rayonnement ultraviolet
+                                - spectral
+                                - large bande
+                                - multibande 
+                                - angle zénithal du soleil
+                                - coup de soleil
+                            extent:
+                                time: 1988-11-18/now
+                            waf_dir: none
+                            levels:
+                                - 2.0:
+                                    label_en: Level 2.0
+                                    networks:
+                                        - uv_index_horly:
+                                            label_en: UV-Index-Hourly
+                                            instruments:
+                                                - kipp-zonen:
+                                                    label_en: Kipp Zonen
+                                                - uv-biometer:
+                                                    label_en: UV-Biometer
+                                                - optronics:
+                                                    label_en: Optronics
+                                                - brewer: *id_brewer_instrument
+                                                - biospherical: *id_biospherical                                
+
+data_metadata:
+    label_en: Data Centre context layers
+    metrics:
+        label_en: Data distribution, submission and access metrics
+        keywords_en: &id_metrics_keywords
+            - data distribution
+            - metrics
+            - statistics
+            - data submission
+            - data access
+        metrics_data_distribution_station:
+            id: id
+            label_en: Data contributions by station
+            description_en: Data distribution metrics, by station, by year
+            keywords_en: *id_metrics_keywords
+        metrics_data_distribution_station_frequency:
+            id: id
+            label_en: Data contributions by station (frequency)
+            description_en: Data distribution metrics, by station, by year
+            keywords_en: *id_metrics_keywords
+        metrics_data_distribution_station_summary:
+            id: id
+            label_en: Data contributions by station (summary)
+            description_en: Data distribution metrics, by station, by year
+            keywords_en: *id_metrics_keywords
+        metrics_data_distribution_dataset:
+            id: id
+            type: polygon
+            label_en: Data contributions by dataset
+            description_en: Data distribution metrics, by dataset, by year
+            keywords_en: *id_metrics_keywords
+        metrics_data_distribution_dataset_frequency:
+            id: id
+            type: polygon
+            label_en: Data contributions by dataset (frequency)
+            description_en: Data distribution metrics, by dataset, by year
+            keywords_en: *id_metrics_keywords
+        metrics_data_distribution_dataset_summary:
+            id: id
+            type: polygon
+            label_en: Data contributions by dataset (summary)
+            description_en: Data distribution metrics, by dataset, by year
+            keywords_en: *id_metrics_keywords
+        metrics_data_distribution_contributor:
+            id: id
+            label_en: Data contributions by contributor
+            description_en: Data distribution metrics, by contributor / dataset / station id, by year
+            keywords_en: *id_metrics_keywords
+        metrics_data_distribution_contributor_network_frequency:
+            id: id
+            label_en: Data contributions by contributor and network (frequency)
+            description_en: Data distribution metrics, by contributor / dataset / station id, by year
+            keywords_en: *id_metrics_keywords
+        metrics_data_distribution_contributor_network_summary:
+            id: id
+            label_en: Data contributions by contributor and network
+            description_en: Data distribution metrics, by contributor / dataset / station id, by year
+            keywords_en: *id_metrics_keywords
+        metrics_network_station_count:
+            id: id
+            label_en: Total Stations Reporting Per Year By Network (Instrument)
+            description_en: Data distribution metrics stations, by network
+            keywords_en: *id_metrics_keywords
+        metrics_data_contribution:
+            id: id
+            label_en: Latest data submission times by contributor
+            description_en: Latest data submission by contributor including elapsed time since last submission
+            keywords_en: *id_metrics_keywords
+        metrics_ftp_access_dataset:
+            id: id
+            label_en: FTP data access metrics by dataset
+            description_en: FTP data access metrics, by dataset, by year/month
+            keywords_en: *id_metrics_keywords
+        metrics_ftp_access_station:
+            id: id
+            label_en: FTP data access metrics by station
+            description_en: FTP data access metrics, by station, by year/month
+            keywords_en: *id_metrics_keywords
+        metrics_ftp_access_instrument:
+            id: id
+            label_en: FTP data access metrics by instrument
+            description_en: FTP data access metrics, by instrument, by year/month
+            keywords_en: *id_metrics_keywords
+        metrics_waf_access_dataset:
+            id: id
+            label_en: WAF data access metrics by dataset
+            description_en: WAF data access metrics, by dataset, by year/month
+            keywords_en: *id_metrics_keywords
+        metrics_waf_access_station:
+            id: id
+            label_en: WAF data access metrics by station
+            description_en: WAF data access metrics, by station, by year/month
+            keywords_en: *id_metrics_keywords
+        metrics_waf_access_instrument:
+            id: id
+            label_en: WAF data access metrics by instrument
+            description_en: WAF data access metrics, by instrument, by year/month
+            keywords_en: *id_metrics_keywords
+        metrics_waf_access_dataset_summary:
+            id: id
+            label_en: WAF data access metrics by dataset (summary)
+            description_en: WAF data access metrics, by dataset, by year/month
+            keywords_en: *id_metrics_keywords
+        metrics_waf_access_station_summary:
+            id: id
+            label_en: WAF data access metrics by station (summary)
+            description_en: WAF data access metrics, by station, by year/month
+            keywords_en: *id_metrics_keywords
+        metrics_waf_access_instrument_summary:
+            id: id
+            label_en: WAF data access metrics by instrument (summary)
+            description_en: WAF data access metrics, by instrument, by year/month
+            keywords_en: *id_metrics_keywords
+        metrics_ows_access_dataset:
+            id: id
+            label_en: OWS data access metrics by dataset
+            description_en: OWS data access metrics, by dataset, by year/month
+            keywords_en: *id_metrics_keywords
+        metrics_ows_access_station:
+            id: id
+            label_en: OWS data access metrics by station
+            description_en: OWS data access metrics, by station, by year/month
+            keywords_en: *id_metrics_keywords
+        metrics_ows_access_instrument:
+            id: id
+            label_en: OWS data access metrics by instrument
+            description_en: OWS data access metrics, by instrument, by year/month
+            keywords_en: *id_metrics_keywords
+        metrics_ows_access_dataset_summary:
+            id: id
+            label_en: OWS data access metrics by dataset (summary)
+            description_en: OWS data access metrics, by dataset, by year/month
+            keywords_en: *id_metrics_keywords
+        metrics_ows_access_station_summary:
+            id: id
+            label_en: OWS data access metrics by station (summary)
+            description_en: OWS data access metrics, by station, by year/month
+            keywords_en: *id_metrics_keywords
+        metrics_ows_access_instrument_summary:
+            id: id
+            label_en: OWS data access metrics by instrument (summary)
+            description_en: OWS data access metrics, by instrument, by year/month
+            keywords_en: *id_metrics_keywords
+    contributors:
+        id: contributor_id
+        label_en: Contributors
+        description_en: Agencies/Institutions who have in the past or are currently contributing data to the WOUDC archive. The WOUDC acknowledges the commitment and dedication of those individuals who provide these data, on an ongoing basis, to this global data archive.
+        keywords_en:
+            - contributors
+            - agencies
+            - organizations
+    stations:
+        id: platform_id
+        label_en: Stations
+        description_en: Stations observing ozone and ultra-violet radiation data
+        keywords_en:
+            - station
+            - platform
+    instruments:
+        id: instrument_id
+        label_en: Instruments
+        description_en: Instruments measuring ozone and ultra-violet radiation data
+        keywords_en:
+            - instrument
+    notifications:
+        id: id
+        label_en: Notifications
+        description_en: Data centre notifications
+        keywords_en:
+            - news
+            - notifications
+            - announcements
+
+# formats
+formats:
+    - ExtendedCSV:
+        label_en: WOUDC Extended CSV format
+    - DataURLFileList:
+        label_en: WOUDC URL file list
+
+# metadata, for OWS Capabilities metadata
+metadata:
+    identification:
+        title: World Ozone and Ultraviolet Radiation Data Centre (WOUDC)
+        abstract: The World Ozone and Ultraviolet Radiation Data Centre (WOUDC) is one of six World Data Centres which are part of the Global Atmosphere Watch (GAW) programme of the World Meteorological Organization (WMO).  WOUDC contains ozone and UV data measured by instruments located on ground-based, shipborne or airborne platforms.  Data are subject to the WOUDC Data Policy (https://woudc.org/about/data-policy.php)
+        keywords_en:
+            - ozone
+            - ultraviolet
+            - uv
+            - totalozone
+            - ozonesonde
+            - umkehr
+            - gaw
+            - wmo
+            - spectral
+            - stations
+            - instruments
+        keywords_type: theme
+        fees: None
+        accessconstraints: None
+    attribution:
+        title: World Meteorological Organization-Global Atmosphere Watch Program (WMO-GAW)/World Ozone and Ultraviolet Radiation Data Centre (WOUDC)
+        url: https://woudc.org/about/data-policy.php
+    provider:
+        name: Government of Canada, Environment and Climate Change Canada, Meteorological Service of Canada, Canadian Centre for Meteorological and Environmental Prediction, National Prediction Development, Geospatial and Open Data Systems
+        url: https://woudc.org
+        contact:
+            name: World Ozone and Ultraviolet Radiation Data Centre
+            position: Data Centre Manager
+            phone:
+                voice: None
+                fax: None
+            address:
+                delivery_point: 4905 Dufferin Street
+                city: Toronto
+                stateorprovince: Ontario
+                postalcode: M3H 5T4
+                country: Canada
+                email: woudc@ec.gc.ca
+            url: https://woudc.org/contact.php
+            hours: 1400h - 2200h UTC
+            instructions: During hours of service
+        role: pointOfContact
+        logo:
+            href: https://woudc.org/static/site/img/gaw_acronym_vertical_sm.jpg
+            format: image/jpeg
+            width: 102
+            height: 150
+
+# peers            
+federated_data_centres:
+    label_en: Related Data Centres
+    ndacc:
+        label_en: Network for the Detection of Atmospheric Composition Change (NDACC)
+        description_en: The international Network for the Detection of Atmospheric Composition Change (NDACC) is composed of more than 70 high-quality, remote-sensing research stations for observing and understanding the physical and chemical state of the stratosphere and upper troposphere and for assessing the impact of stratosphere changes on the underlying troposphere and on global climate.
+        url: https://ndaccdemo.org
+        source: ftp://ftp.cpc.ncep.noaa.gov/ndacc/ndacc_csv_for_geomon.txt
+        keywords_en:
+            - atmospheric
+            - composition
+            - detection
+            - remote sensing
+            - troposphere
+            - stratosphere
+            - climate
+        extent:
+            time: YYYY-MM-DD/now
+        attribution:
+            title: Network for the Detection of Atmospheric Composition Change (NDACC)
+            url: https://ndaccdemo.org
+        logo:
+            href: https://ndaccdemo.org/sites/all/themes/custom/ndacc/images/ndacc-badge2.png
+            format: image/gif
+            width: 238
+            height: 176
+    eubrewnet:
+        label_en: European Brewer Network
+        description_en: European Brewer Network
+        url: http://www.eubrewnet.org
+        source: ftp://ftp.cpc.ncep.noaa.gov/ndacc/ndacc_csv_for_geomon.txt
+        keywords_en:
+            - europe
+            - brewer
+            - ozone
+            - climate
+        extent:
+            time: YYYY-MM-DD/now
+        attribution:
+            title: European Brewer Network
+            url: http://www.eubrewnet.org
+        logo:
+            href: http://www.eubrewnet.org/eubrewnet/static/logos/logo_eubrewnet.jpg
+            format: image/jpg
+            width: 273
+            height: 76

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click
 elasticsearch<8
-jsonschema
+jsonschema<4.4.0
 pyyaml
 requests
 sqlalchemy

--- a/woudc_data_registry/controller.py
+++ b/woudc_data_registry/controller.py
@@ -56,6 +56,7 @@ from woudc_data_registry.parser import (ExtendedCSV, NonStandardDataError,
                                         MetadataValidationError)
 from woudc_data_registry.processing import Process
 
+from woudc_data_registry.generate_metadata import update_extents
 from woudc_data_registry.models import Contributor
 from woudc_data_registry.registry import Registry
 from woudc_data_registry.report import OperatorReport, RunReport, EmailSummary
@@ -232,6 +233,7 @@ def ingest(ctx, source, reports_dir, lax, bypass):
     """ingest a single data submission or directory of files"""
 
     orchestrate(source, reports_dir, metadata_only=lax, bypass=bypass)
+    update_extents()
 
 
 @click.command()

--- a/woudc_data_registry/generate_metadata.py
+++ b/woudc_data_registry/generate_metadata.py
@@ -1,0 +1,562 @@
+# -*- coding: utf-8 -*-
+# =================================================================
+#
+# Terms and Conditions of Use
+#
+# Unless otherwise noted, computer program source code of this
+# distribution is covered under Crown Copyright, Government of
+# Canada, and is distributed under the MIT License.
+#
+# The Canada wordmark and related graphics associated with this
+# distribution are protected under trademark law and copyright law.
+# No permission is granted to use them outside the parameters of
+# the Government of Canada's corporate identity program. For
+# more information, see
+# http://www.tbs-sct.gc.ca/fip-pcim/index-eng.asp
+#
+# Copyright title to all 3rd party software distributed with this
+# software is held by the respective copyright holders as noted in
+# those files. Users are asked to read the 3rd Party Licenses
+# referenced with those assets.
+#
+# Copyright (c) 2022 Government of Canada
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+import json
+import logging
+from woudc_data_registry.registry import Registry
+import woudc_data_registry.models
+
+
+LOGGER = logging.getLogger(__name__)
+
+WOUDC_OWS = 'https://geo.woudc.org/ows'
+
+
+def generate_metadata(woudc_yaml):
+    """generate list of MCF ConfigParser objects from WOUDC YAML"""
+
+    u1 = u2 = None
+    dict_list = []
+    geojson_list = []
+    uri_pre = 'https://geo.woudc.org/def/data'
+
+    topiccategory = 'climatologyMeteorologyAtmosphere'
+
+    data_categories = woudc_yaml['data']['data_categories']
+
+    # Go through each dataset collection
+    for data_category in data_categories:
+        for key, value in data_category.items():
+            for datasetcollection in data_category[key]['datasetcollections']:
+                for key1, value1 in datasetcollection.items():
+                    # Find umkehr and duplicate for levels 1.0 and 2.0
+                    for dataset in value1['datasets']:
+                        if 'UmkehrN14' in dataset:
+                            u1 = {'UmkehrN14_1.0':
+                                  dataset['UmkehrN14']['levels'][0][1.0]
+                                  }
+                            u2 = {'UmkehrN14_2.0':
+                                  dataset['UmkehrN14']['levels'][1][2.0]
+                                  }
+                            u1['UmkehrN14_1.0']['label_en'] = \
+                                '%s (%s)' % \
+                                (dataset['UmkehrN14']['label_en'],
+                                 dataset['UmkehrN14']['levels'][0]
+                                 [1.0]['label_en']
+                                 )
+                            u2['UmkehrN14_2.0']['label_fr'] = \
+                                '%s (%s)' % \
+                                (dataset['UmkehrN14']['label_en'],
+                                 dataset['UmkehrN14']['levels'][1]
+                                 [2.0]['label_fr']
+                                 )
+                            value1['datasets'].remove(dataset)
+                            value1['datasets'].append(u1)
+                            value1['datasets'].append(u2)
+
+                    for dataset in value1['datasets']:
+                        for key2, value2 in dataset.items():
+                            # Metadata dictionary for current dataset
+                            dataset_md = {"type": "Feature",
+                                          "properties": {},
+                                          "geometry": None
+                                          }
+
+                            uri = '{}/{}/{}/{}'.format(
+                                      uri_pre, key, key1, key2
+                                  )
+                            time_begin, time_end = \
+                                value1['extent']['time'].split('/')
+                            dataset_md["id"] = key2
+                            dataset_md['properties']['abstract_en'] = \
+                                value2['description_en']
+                            dataset_md['properties']['abstract_fr'] = \
+                                value2['description_fr']
+                            dataset_md["properties"]['doi'] = value2['doi']
+                            dataset_md['properties']['keywords_en'] = \
+                                value2['keywords_en']
+                            dataset_md['properties']['keywords_fr'] = \
+                                value2['keywords_fr']
+                            dataset_md['properties']['temporal_begin'] = \
+                                time_begin
+                            dataset_md['properties']['temporal_end'] = \
+                                time_end
+                            dataset_md['properties']['spatial_extent'] = \
+                                [-180, -90, 180, 90]
+                            dataset_md['properties']['title_en'] = \
+                                value2['label_en']
+                            dataset_md['properties']['title_fr'] = \
+                                value2['label_fr']
+                            dataset_md['properties']['topic_category'] = \
+                                topiccategory
+                            dataset_md['properties']['url'] = uri
+
+                            names = []
+                            if 'levels' in value2:
+                                levels = []
+                                for level in value2['levels']:
+                                    for key3, value3 in level.items():
+                                        curr_level = {
+                                            'label_en':
+                                                level[key3]['label_en'],
+                                            'networks': []
+                                        }
+                                        networks = []
+                                        for ntwk in value3['networks']:
+                                            curr_network = {}
+                                            for key4, value4 in ntwk.items():
+                                                curr_network['label_en'] = \
+                                                    value4['label_en']
+                                                if 'instruments' in value4:
+                                                    names = []
+                                                    if isinstance(
+                                                        value4['instruments'],
+                                                        list
+                                                    ):
+                                                        for i in value4[
+                                                         'instruments'
+                                                        ]:
+                                                            for key5, value5 \
+                                                             in i.items():
+                                                                if key5 in [
+                                                                  'label_en',
+                                                                  'label_fr'
+                                                                 ]:
+                                                                    pass
+                                                                else:
+                                                                    names\
+                                                                      .append(
+                                                                        key5
+                                                                      )
+                                                    curr_network[
+                                                      'instruments'
+                                                    ] = names
+                                            networks.append(curr_network)
+                                            curr_level['networks'] = networks
+                                    levels.append(curr_level)
+                                dataset_md['properties']['levels'] = levels
+                            else:  # umkehr
+                                levels = []
+                                if key2 == 'UmkehrN14 (Level 1.0)':
+                                    label_en = 'Level 1.0'
+                                else:
+                                    label_en = 'Level 2.0'
+                                curr_level = {
+                                            'label_en': label_en,
+                                            'networks': []
+                                        }
+                                networks = []
+                                for n in value2['networks']:
+                                    curr_network = {}
+                                    for key4, value4 in n.items():
+                                        if 'instruments' in value4:
+                                            curr_network['label_en'] = \
+                                                value4['label_en']
+                                            names = []
+                                            if isinstance(
+                                              value4['instruments'],
+                                              list
+                                            ):
+                                                for instrument in value4[
+                                                  'instruments'
+                                                ]:
+                                                    for key5, value5 in \
+                                                      instrument.items():
+                                                        if key5 in [
+                                                          'label_en',
+                                                          'label_fr'
+                                                        ]:
+                                                            pass
+                                                        else:
+                                                            names.append(key5)
+                                        curr_network['instruments'] = names
+                                        networks.append(curr_network)
+                                curr_level['networks'] = networks
+                                levels.append(curr_level)
+                                dataset_md['properties']['levels'] = levels
+
+                            if value2['waf_dir'] != 'None':
+                                dataset_md['properties']['waf'] = {
+                                    'url':
+                                        'https://woudc.org/archive/'
+                                        'Archive-NewFormat/{}'.format(
+                                            value2['waf_dir']
+                                        ),
+                                    'linktype': 'WWW:LINK',
+                                    'function': 'download',
+                                    'label_en': value2['label_en'],
+                                    'label_fr': value2['label_fr'],
+                                    'description_en':
+                                        'Web Accessible Folder (WAF)',
+                                    'description_fr':
+                                        'Dossier accessible sur le web '
+                                        '(WAF)'
+                                }
+
+                            dataset_md['properties']['dataset_snapshots'] = {
+                                'url':
+                                    'https://woudc.org/archive/Summaries'
+                                    '/dataset-snapshots/'
+                                    '{}.zip'.format(key2),
+                                'linktype': 'WWW:LINK',
+                                'function': 'download',
+                                'label_en': value2['label_en'],
+                                'label_fr': value2['label_fr'],
+                                'description_en':
+                                    'Static dataset archive file',
+                                'description_fr':
+                                    'La donnée d\'archive statique'
+                            }
+
+                            dataset_md['properties']['wms'] = {
+                                'url': '{}?service={}'
+                                       '&version={}&'
+                                       'request=GetCapabilities'
+                                       .format(WOUDC_OWS, 'WMS', '1.3.0'),
+                                'linktype': 'OGC:WMS',
+                                'function': 'download',
+                                'label_en': key2,
+                                'label_fr': key2,
+                                'description_en': 'OGC Web Map Service (WMS)',
+                                'description_fr': 'OGC Web Map Service (WMS)'
+                            }
+
+                            dataset_md['properties']['wfs'] = {
+                                'url': '{}?service={}'
+                                       '&version={}&'
+                                       'request=GetCapabilities'
+                                       .format(WOUDC_OWS, 'WFS', '1.3.0'),
+                                'linktype': 'OGC:WFS',
+                                'function': 'download',
+                                'label_en': key2,
+                                'label_fr': key2,
+                                'description_en':
+                                    'OGC Web Feature Service (WFS)',
+                                'description_fr':
+                                    'OGC Web Feature Service (WFS)'
+                             }
+
+                            dataset_md['properties']['search'] = {
+                                'url':
+                                    'https://woudc.org/data/explore.php'
+                                    '?dataset={}'.format(key2),
+                                'linktype': 'WWW:LINK',
+                                'function': 'search',
+                                'label_en': value2['label_en'],
+                                'label_fr': value2['label_fr'],
+                                'description_en':
+                                    'Data Search / Download User Interface',
+                                'description_fr':
+                                    u'Interface de recherche et '
+                                    'téléchargement de données'
+                            }
+
+                            geojson_list.append((key2, dataset_md))
+
+    for dataset in geojson_list:
+        discovery_metadata_id = dataset[0]
+        metadata = json.dumps(dataset[1])
+        metadata = metadata.replace('"', '\\"')
+        curr_dict = {
+            "discovery_metadata_id": discovery_metadata_id,
+            "metadata": metadata
+        }
+        dict_list += [curr_dict]
+
+    return dict_list
+
+
+def update_extents():
+    # Update metadata for each row in DiscoveryMetadata table
+    [
+      DataRecord, UVIndex, OzoneSonde, TotalOzone,
+      DiscoveryMetadata, Instrument
+    ] = [
+      woudc_data_registry.models.DataRecord,
+      woudc_data_registry.models.UVIndex,
+      woudc_data_registry.models.OzoneSonde,
+      woudc_data_registry.models.TotalOzone,
+      woudc_data_registry.models.DiscoveryMetadata,
+      woudc_data_registry.models.Instrument
+    ]
+
+    inputs = {
+        'ozonesonde': {
+            'content_category': 'OzoneSonde',
+            'ins_id': OzoneSonde.instrument_id,
+            'date_field': OzoneSonde.timestamp_date,
+            'label_en': 'OzoneSonde',
+            'levels': ['1.0'],
+            'model': OzoneSonde
+        },
+        'totalozone': {
+            'content_category': 'TotalOzone',
+            'ins_id': TotalOzone.instrument_id,
+            'date_field': TotalOzone.observation_date,
+            'label_en': 'TotalOzone',
+            'levels': ['1.0', '2.0'],
+            'model': TotalOzone
+        },
+        'uv_index_hourly': {
+            'content_category': 'uv_index_hourly',
+            'ins_id': UVIndex.instrument_id,
+            'date_field': UVIndex.observation_date,
+            'label_en': 'UV-Index-Hourly',
+            'levels': ['2.0'],
+            'model': UVIndex
+        }
+    }
+    # Connect to registry and update dataset metadata
+    registry = Registry()
+    # Select all rows from discovery_metadata
+    datasets_class_list = registry.query_full_index(DiscoveryMetadata)
+    datasets = []
+    for curr_dataset in datasets_class_list:
+        datasets += [(curr_dataset.discovery_metadata_id,
+                      curr_dataset._metadata)]
+    LOGGER.debug('Updating Discovery Metadata table...')
+    tables = ['ozonesonde', 'totalozone', 'uv_index_hourly', 'data_records']
+
+    for input_table in tables:
+        if input_table == 'data_records':
+            # Select data records content categories
+            categories = registry.query_distinct(DataRecord.content_category)
+            # Loop through each dataset and update the geoJSON
+            for (dataset, md) in datasets:
+                md_loads = json.loads(md.replace('\\"', '"'))
+                if dataset in categories:
+                    # Update spatial/temporal extents
+                    extents = registry.query_extents(
+                                      DataRecord,
+                                      DataRecord.timestamp_date,
+                                      'content_category',
+                                      dataset)[0]
+
+                    md_loads['properties']['spatial_extent'] = [extents[2],
+                                                                extents[3],
+                                                                extents[4],
+                                                                extents[5]]
+                    md_loads['properties']['temporal_begin'] = str(extents[0])
+                    md_loads['properties']['temporal_end'] = str(extents[1])
+                    # Update levels and networks
+                    values = {'content_category': dataset}
+                    levels = registry.query_distinct_by_fields(
+                                DataRecord.content_level,
+                                DataRecord,
+                                values
+                    )
+                    if 'levels' not in md_loads['properties']:
+                        # Add levels field if it does not already exist
+                        md_loads['properties']['levels'] = []
+                    for curr_level in levels:
+                        is_included = False
+                        for level in md_loads['properties']['levels']:
+                            if level['label_en'] == 'Level {}'.format(
+                              curr_level
+                            ):
+                                is_included = True
+                        if not is_included:
+                            if dataset.startswith(('TotalOzone', 'UmkehrN14')):
+                                label_en = 'Other'
+                            else:
+                                label_en = dataset
+                            # Add level item if it does not already exist
+                            md_loads['properties']['levels'].append(
+                                {'label_en': 'Level {}'.format(curr_level),
+                                 'networks': [{
+                                     'label_en': label_en,
+                                     'instruments': []
+                                 }]
+                                 })
+                        # Get distinct instruments for current level
+                        values = {
+                            'content_category': dataset,
+                            'content_level': curr_level
+                        }
+                        subquery = registry.query_distinct_by_fields(
+                                       DataRecord.instrument_id,
+                                       DataRecord,
+                                       values
+                        )
+                        instruments = registry.query_distinct_in(
+                                       Instrument.name,
+                                       Instrument.instrument_id,
+                                       subquery
+                        )
+                        for level in md_loads['properties']['levels']:
+                            if level['label_en'] == 'Level {}'.format(
+                              curr_level
+                            ):
+                                for ins in instruments:
+                                    is_included = False
+                                    otherIndex = [False, -1]
+                                    for n in level['networks']:
+                                        if n['label_en'] == 'Other':
+                                            otherIndex = [True,
+                                                          level[
+                                                            'networks'
+                                                          ].index(n)]
+                                        if ins.lower() in n['instruments']:
+                                            is_included = True
+                                    if not is_included:
+                                        if dataset.startswith(
+                                                   ('TotalOzone', 'UmkehrN14')
+                                        ):
+                                            if ins.lower() in [
+                                               'brewer', 'dobson', 'saoz']:
+                                                level['networks'].append({
+                                                    'label_en': ins,
+                                                    'instruments': [
+                                                      ins.lower()
+                                                    ]
+                                                })
+
+                                            elif otherIndex[0]:
+                                                level['networks'][
+                                                    otherIndex[1]][
+                                                    'instruments'
+                                                ].append(ins.lower())
+                                            else:
+                                                level['networks'].append({
+                                                    'label_en': 'Other',
+                                                    'instruments': [
+                                                        ins.lower()
+                                                    ]
+                                                })
+                                        else:
+                                            level['networks'][0][
+                                              'instruments'
+                                            ].append(ins.lower())
+                                for network in level['networks']:
+                                    # Remove any empty networks
+                                    if len(network['instruments']) == 0:
+                                        level['networks'].remove(network)
+
+                    md_updated = json.dumps(md_loads)
+                    md_updated = md_updated.replace('"', '\\"').replace(
+                        "'", "''"
+                    )
+                    # Update metadata in corresponding row
+                    new_value = {'_metadata': md_updated}
+                    registry.update_by_field(
+                      new_value, DiscoveryMetadata,
+                      'discovery_metadata_id', dataset
+                    )
+
+        else:
+            for (dataset, md) in datasets:
+                if dataset == inputs[input_table]['content_category']:
+                    break
+            md_loads = json.loads(md.replace('\\"', '"'))
+
+            # Update spatial/temporal extents
+            extents = registry.query_extents(
+               inputs[input_table]['model'], inputs[input_table]['date_field']
+            )[0]
+            md_loads['properties']['spatial_extent'] = [extents[2],
+                                                        extents[3],
+                                                        extents[4],
+                                                        extents[5]]
+            md_loads['properties']['temporal_begin'] = str(extents[0])
+            md_loads['properties']['temporal_end'] = str(extents[1])
+            # Update levels and networks
+            levels = inputs[input_table]['levels']
+            if 'levels' not in md_loads['properties']:
+                # Add levels field if it does not already exist
+                md_loads['properties']['levels'] = []
+
+            for curr_level in levels:
+                is_included = False
+                for level in md_loads['properties']['levels']:
+                    if level['label_en'] == 'Level {}'.format(curr_level):
+                        is_included = True
+                if not is_included:
+                    # Add level item if it does not already exist
+                    md_loads['properties']['levels'].append(
+                        {
+                          'label_en': 'Level {}'.format(curr_level),
+                          'networks': [{
+                              'label_en': inputs[input_table]['label_en'],
+                              'instruments': []
+                          }]
+                        }
+                    )
+
+                # Get distinct instruments for current level
+                subquery = registry.query_distinct(
+                               inputs[input_table]['ins_id']
+                )
+                instruments = registry.query_distinct_in(
+                               Instrument.name,
+                               Instrument.instrument_id,
+                               subquery
+                )
+                for level in md_loads['properties']['levels']:
+                    if level['label_en'] == 'Level {}'.format(curr_level):
+                        for ins in instruments:
+                            is_included = False
+                            for n in level['networks']:
+                                if ins.lower() in n['instruments']:
+                                    is_included = True
+                            if not is_included:
+                                level['networks'][0]['instruments'].append(
+                                    ins.lower()
+                                )
+                        for network in level['networks']:
+                            # Remove any empty networks
+                            if len(network['instruments']) == 0:
+                                level['networks'].remove(network)
+
+            md_updated = json.dumps(md_loads)
+            md_updated = md_updated.replace('"', '\\"').replace("'", "''")
+            # Update metadata in corresponding row
+            new_value = {'_metadata': md_updated}
+            registry.update_by_field(
+                new_value, DiscoveryMetadata, 'discovery_metadata_id', dataset
+            )
+
+    registry.close_session()
+    return True

--- a/woudc_data_registry/product/ozonesonde/__init__.py
+++ b/woudc_data_registry/product/ozonesonde/__init__.py
@@ -46,6 +46,7 @@
 import click
 from woudc_data_registry.product.ozonesonde.ozonesonde_generator \
     import generate_ozonesonde
+from woudc_data_registry.generate_metadata import update_extents
 
 
 @click.group()
@@ -74,6 +75,8 @@ def generate(ctx, srcdir, bypass=False):
 
     if bypass_:
         generate_ozonesonde(srcdir, bypass)
+
+    update_extents()
 
 
 ozonesonde.add_command(generate)

--- a/woudc_data_registry/product/totalozone/__init__.py
+++ b/woudc_data_registry/product/totalozone/__init__.py
@@ -46,6 +46,7 @@
 import click
 from woudc_data_registry.product.totalozone.totalozone_generator \
     import generate_totalozone
+from woudc_data_registry.generate_metadata import update_extents
 
 
 @click.group()
@@ -74,6 +75,8 @@ def generate(ctx, srcdir, bypass=False):
 
     if bypass_:
         generate_totalozone(srcdir, bypass)
+
+    update_extents()
 
 
 totalozone.add_command(generate)

--- a/woudc_data_registry/product/uv_index/__init__.py
+++ b/woudc_data_registry/product/uv_index/__init__.py
@@ -44,6 +44,7 @@
 # =================================================================
 
 import click
+from woudc_data_registry.generate_metadata import update_extents
 from woudc_data_registry.product.uv_index.uv_index_generator \
     import generate_uv_index
 
@@ -73,6 +74,8 @@ def generate(ctx, srcdir, bypass=False):
 
     if bypass_:
         generate_uv_index(srcdir, False, None, None, bypass)
+
+    update_extents()
 
 
 @click.command()

--- a/woudc_data_registry/search.py
+++ b/woudc_data_registry/search.py
@@ -62,6 +62,40 @@ typedefs = {
     }
 }
 
+dataset_links = {
+    'type': 'nested',
+    'properties': {
+        'label_en': {
+            'type': 'text',
+            'fields': {'raw': typedefs['keyword']}
+        },
+        'label_fr': {
+            'type': 'text',
+            'fields': {'raw': typedefs['keyword']}
+        },
+        'description_en': {
+            'type': 'text',
+            'fields': {'raw': typedefs['keyword']}
+        },
+        'description_fr': {
+            'type': 'text',
+            'fields': {'raw': typedefs['keyword']}
+        },
+        'function': {
+            'type': 'text',
+            'fields': {'raw': typedefs['keyword']}
+        },
+        'linktype': {
+            'type': 'text',
+            'fields': {'raw': typedefs['keyword']}
+        },
+        'url': {
+            'type': 'text',
+            'fields': {'raw': typedefs['keyword']}
+        }
+    }
+}
+
 DATE_FORMAT = 'date_time_no_millis'
 
 MAPPINGS = {
@@ -170,6 +204,89 @@ MAPPINGS = {
                 'type': 'date',
                 'format': DATE_FORMAT
             }
+        }
+    },
+    'discovery_metadata': {
+        'index': 'discovery_metadata',
+        'properties': {
+            'identifier': {
+                'type': 'text',
+                'fields': {'raw': typedefs['keyword']}
+            },
+            'abstract_en': {
+                'type': 'text',
+                'fields': {'raw': typedefs['keyword']}
+            },
+            'abstract_fr': {
+                'type': 'text',
+                'fields': {'raw': typedefs['keyword']}
+            },
+            'dataset_snapshots': dataset_links,
+            'doi': {
+                'type': 'text',
+                'fields': {'raw': typedefs['keyword']}
+            },
+            'keywords_en': {
+                'type': 'text',
+                'fields': {'raw': typedefs['keyword']}
+            },
+            'keywords_fr': {
+                'type': 'text',
+                'fields': {'raw': typedefs['keyword']}
+            },
+            'levels': {
+                'type': 'nested',
+                'properties': {
+                    'label_en': {
+                        'type': 'text',
+                        'fields': {'raw': typedefs['keyword']}
+                    },
+                    'networks': {
+                        'type': 'nested',
+                        'properties': {
+                            'instruments': {
+                                'type': 'text',
+                                'fields': {'raw': typedefs['keyword']}
+                            },
+                            'label_en': {
+                                'type': 'text',
+                                'fields': {'raw': typedefs['keyword']}
+                            }
+                        }
+                    }
+                }
+            },
+            'search': dataset_links,
+            'spatial_extent': {
+                'type': 'long',
+                'fields': {'raw': typedefs['keyword']}
+            },
+            'temporal_begin': {
+                'type': 'text',
+                'fields': {'raw': typedefs['keyword']}
+            },
+            'temporal_end': {
+                'type': 'text',
+                'fields': {'raw': typedefs['keyword']}
+            },
+            'title_en': {
+                'type': 'text',
+                'fields': {'raw': typedefs['keyword']}
+            },
+            'title_fr': {
+                'type': 'text',
+                'fields': {'raw': typedefs['keyword']}
+            },
+            'topic_category': {
+                'type': 'text',
+                'fields': {'raw': typedefs['keyword']}
+            },
+            'url': {
+                'type': 'text',
+                'fields': {'raw': typedefs['keyword']}
+            },
+            'waf': dataset_links,
+            'wms': dataset_links
         }
     },
     'stations': {


### PR DESCRIPTION
Add `discovery_metadata` table to psql and index on ElasticSearch. Read yaml file at `data/woudc.skos.yaml` and create corresponding geoJSON for each of the 11 datasets, inserting the json metadata into a new table on the psql database and  a new index on ElasticSearch.  
  
The setup and initialization of the psql table were added to the following existing commands:  
`woudc-data-registry admin registry setup`  
`woudc-data-registry admin init -d data`   
Spatiotemporal extents and dataset levels are updated on ingest.
  
The index is set up to Elasticsearch through the command:
`woudc-data-registry admin search setup`
The index is synced to Elasticsearch through the command:
`woudc-data-registry admin search sync`