### PR TITLE
Remove character substitutions in metadata update

### DIFF
--- a/woudc_data_registry/generate_metadata.py
+++ b/woudc_data_registry/generate_metadata.py
@@ -566,7 +566,6 @@ def update_extents():
                                 level['networks'].remove(network)
 
             md_updated = json.dumps(md_loads)
-            md_updated = md_updated.replace('"', '\\"').replace("'", "''")
             # Update metadata in corresponding row
             new_value = {'_metadata': md_updated}
             registry.update_by_field(


### PR DESCRIPTION
Remove character substitutions in discovery metadata update function (`generate_metadata.update_extents`), as the substitutions are not required by woudc-data-registry's Registry class.