### PR TITLE
added clear index flag in search sync and product sync

### DIFF
--- a/woudc_data_registry/models.py
+++ b/woudc_data_registry/models.py
@@ -2750,7 +2750,10 @@ def backup(ctx, datadir):
 @click.pass_context
 @cli_options.OPTION_VERBOSITY
 @click.option('--models', '-m', help='class to sync', is_flag=False)
-def sync(ctx, models, verbosity):
+@click.option('--clear-index', '-c', is_flag=True,
+              help='Delete all documents in search indices (unless models is'
+              'specified, then only clear indices in models) before syncing')
+def sync(ctx, models, clear_index, verbosity):
     """Sync search index with data registry"""
     # want to add an option to specify the class to sync
     model_classes = []
@@ -2805,6 +2808,12 @@ def sync(ctx, models, verbosity):
             continue
 
         click.echo(f'{plural_caps}...')
+
+        # check if we want to clear index first
+        if clear_index:
+            click.echo(f"Clearing search index for {plural_name}")
+            search_index.clear(plural_name)
+
         if plural_caps == 'DataRecords':
             capacity = 10000
             for obj in registry_.session.query(clazz).yield_per(1):
@@ -2839,7 +2848,11 @@ def sync(ctx, models, verbosity):
 @click.pass_context
 @cli_options.OPTION_VERBOSITY
 @click.option('--models', '-m', help='class to sync', is_flag=False)
-def product_sync(ctx, models, verbosity):
+@click.option('--clear-index', '-c', is_flag=True,
+              help='Delete all documents in product search indices (unless'
+              'models is specified, then only clear product indices in models)'
+              'before syncing')
+def product_sync(ctx, models, clear_index, verbosity):
     """Sync products to Elasticsearch"""
 
     products = []
@@ -2887,6 +2900,11 @@ def product_sync(ctx, models, verbosity):
             continue  # Skip to the next product in the loop
 
         click.echo(f'{plural_caps}...')
+
+        # check if we want to clear index first
+        if clear_index:
+            click.echo(f"Clearing search indexes for {plural_name}")
+            search_index.clear(plural_name)
 
         registry_contents = []
         # Sync product to elasticsearch

--- a/woudc_data_registry/search.py
+++ b/woudc_data_registry/search.py
@@ -1331,6 +1331,78 @@ class SearchIndex(object):
                     f"index '{index_name}': {err}"
                 )
 
+    def clear(self, model):
+        """
+        clear search indexes
+
+        :param model: table name of the index to clear
+        """
+
+        large_indices = ['data_records', 'uv_index_hourly',
+                         'totalozone', 'ozonesonde']
+
+        search_index_config = config.EXTRAS.get('search_index', {})
+
+        MAPPINGS_FILTERED = {}
+
+        if model is not None and model in MAPPINGS_ALL:
+            MAPPINGS_FILTERED = {model: MAPPINGS_ALL[model]}
+        else:  # clear all models
+            MAPPINGS_FILTERED = deepcopy(MAPPINGS_ALL)
+
+        # Skip indexes that have been manually disabled.
+        enabled_flag = f'{model}_enabled'
+        if not search_index_config.get(enabled_flag, True):
+            return None
+
+        index_name = self.generate_index_name(MAPPINGS_FILTERED[model][
+            'index'])
+
+        try:
+            LOGGER.info(f'deleting documents from index: {index_name}')
+            if model in large_indices:
+                # too big to clear index, teardown + setup
+                self.delete([model])
+                self.create([model])
+            else:
+                self.connection.delete_by_query(index=index_name,
+                                                body={"query": {
+                                                    "match_all": {}}},
+                                                slices="auto",
+                                                wait_for_completion=True)
+            # to display the number of docs deleted on ES
+            self.connection.indices.refresh(index=index_name)
+        except NotFoundError as err:
+            msg = (
+                f"Index '{index_name}' not found. Skipping document"
+                "deletion.\n"
+                f"{err}"
+            )
+            LOGGER.warning(msg)
+            click.echo(msg)
+
+        except TlsError as err:
+            LOGGER.error(
+                "TLS error occurred while trying to delete "
+                f"index '{index_name}': {err}"
+            )
+            raise SearchIndexError(
+                "TLS error while clearing documents "
+                f"index '{index_name}': {err}.\n"
+                "Check your SSL certificates or set "
+                "WDR_SEARCH_CERT_VERIFY=False if "
+                "connecting to an internal dev server."
+            )
+        except Exception as err:
+            LOGGER.error(
+                "Unexpected error occurred while clearing documents "
+                f"index '{index_name}': {err}"
+            )
+            raise SearchIndexError(
+                "Unexpected error while clearing documents "
+                f"index '{index_name}': {err}"
+            )
+
     def get_record_version(self, identifier):
         """
         get version of data record


### PR DESCRIPTION
- add clear index option to search sync and product sync to delete documents in indices before syncing
- if models is specified and clear-index is used, then only documents from the specified models will be deleted and synced
- handle timeout error for large indices (DataRecord, UVIndex, etc) by using teardown + setup rather than clear 