### PR TITLE
Fix instrument add error in WDR + error handle new instruments

### DIFF
--- a/data/migrate/Errors-Backfilling.csv
+++ b/data/migrate/Errors-Backfilling.csv
@@ -106,8 +106,8 @@ Error Code,Error Type,Message Template,Notes
 328,Warning,#LOCATION.Height in file does not match registry
 329,Warning,Null value found for #INSTRUMENT.Model
 330,Warning,Null value found for #INSTRUMENT.Number
-331,Error,#INSTRUMENT.Name not found in registry
-332,Error,#INSTRUMENT.Model not found in registry
+331,Error,#INSTRUMENT.Name ({name}) not found in registry. Please add instrument to registry using WDR command, reserved for cases where instrument name is not found in registry
+332,Error,#INSTRUMENT.Model ({model}) not found in registry. Please add instrument to registry using WDR command, reserved for cases where instrument model is not found in registry
 333,Error,Instrument failed to validate against registry
 334,Error,Deployment {ident} not found in registry
 335,Warning,Failed to parse #{table}.{field} due to errors: {reason}

--- a/data/migrate/Errors-Weekly-Processing.csv
+++ b/data/migrate/Errors-Weekly-Processing.csv
@@ -106,8 +106,8 @@ Error Code,Error Type,Message Template,Notes
 328,Warning,#LOCATION.Height in file does not match registry
 329,Warning,Null value found for #INSTRUMENT.Model
 330,Warning,Null value found for #INSTRUMENT.Number
-331,Error,#INSTRUMENT.Name not found in registry
-332,Error,#INSTRUMENT.Model not found in registry
+331,Error,#INSTRUMENT.Name ({name}) not found in registry. Please add instrument to registry using WDR command, reserved for cases where instrument name is not found in registry
+332,Error,#INSTRUMENT.Model ({model}) not found in registry. Please add instrument to registry using WDR command, reserved for cases where instrument model is not found in registry
 333,Error,Instrument failed to validate against registry
 334,Error,Deployment {ident} not found in registry
 335,Error,Failed to parse #{table}.{field} due to errors: {reason}

--- a/woudc_data_registry/epicentre/deployment.py
+++ b/woudc_data_registry/epicentre/deployment.py
@@ -117,8 +117,8 @@ def show(ctx, identifier, verbosity):
 @click.pass_context
 @cli_options.OPTION_VERBOSITY
 @click.option('-s', '--station', 'station', required=True, help='station')
-@click.option('-c', '--contributor', 'contributor', required=True,
-              help='contributor')
+@click.option('-c', '--contributor ID', 'contributor', required=True,
+              help='contributor ID: [acronym]:[project]')
 @click.option('-sd', '--start', 'start_date', required=False,
               default=date.today().strftime('%Y-%m-%d'),
               type=click.DateTime(['%Y-%m-%d']), help='deployment start date')

--- a/woudc_data_registry/epicentre/instrument.py
+++ b/woudc_data_registry/epicentre/instrument.py
@@ -78,18 +78,13 @@ def build_instrument(ecsv):
     timestamp_date = ecsv.extcsv['TIMESTAMP']['Date']
 
     dataset_id = f"{dataset_name}_{dataset_level}"
-    instrument_id = ':'.join([name, model, serial,
-                              station, dataset_id, contributor])
 
     model = {
-        'identifier': instrument_id,
         'name': name,
         'model': model,
         'serial': serial,
         'station_id': station,
         'dataset_id': dataset_id,
-        'dataset_name': dataset_name,
-        'dataset_level': dataset_level,
         'dataset_form': dataset_form,
         'contributor': contributor,
         'project': project,
@@ -140,12 +135,13 @@ def show(ctx, identifier, verbosity):
 
 @click.command()
 @click.pass_context
+@cli_options.OPTION_VERBOSITY
 @click.option('-st', '--station', 'station', required=True,
               help='station ID')
 @click.option('-d', '--dataset', 'dataset', required=True,
               help='dataset ID: [dataset]_[dataset_level]')
 @click.option('-c', '--contributor', 'contributor', required=True,
-              help='contributor ID')
+              help='contributor ID: [acronym]:[project]')
 @click.option('-n', '--name', 'name', required=True, help='instrument name')
 @click.option('-m', '--model', 'model', required=True,
               help='instrument model')
@@ -161,11 +157,14 @@ def add(ctx, station, dataset, contributor, name, model, serial, geometry,
     if len(geom_tokens) == 2:
         geom_tokens.append(None)
 
+    project = contributor.split(':')[1]
+    contributor = contributor.split(':')[0]
+
     instrument_ = {
         'station_id': station,
         'dataset_id': dataset,
-        'contributor': contributor.split(':')[0],
-        'project': contributor.split(':')[1],
+        'contributor': contributor,
+        'project': project,
         'name': name,
         'model': model,
         'serial': serial,
@@ -187,7 +186,8 @@ def add(ctx, station, dataset, contributor, name, model, serial, geometry,
               help='identifier')
 @click.option('-st', '--station', 'station', help='station ID')
 @click.option('-d', '--dataset', 'dataset', help='dataset')
-@click.option('-c', '--contributor', 'contributor', help='contributor ID')
+@click.option('-c', '--contributor', 'contributor',
+              help='contributor ID: [acronym]:[project]')
 @click.option('-n', '--name', 'name', help='instrument name')
 @click.option('-m', '--model', 'model', help='instrument model')
 @click.option('-s', '--serial', 'serial', help='instrument serial number')

--- a/woudc_data_registry/models.py
+++ b/woudc_data_registry/models.py
@@ -337,21 +337,15 @@ class Instrument(base):
         self.name = dict_['name']
         self.model = dict_['model']
         self.serial = dict_['serial']
-
-        original_columns = [
-            'dataset_name', 'dataset_level', 'contributor', 'project'
-        ]
-
-        if set(original_columns).issubset(dict_.keys()):
-            self.dataset_name = dict_.get('dataset_name', 'None')
-            self.dataset_level = str(float(dict_.get('dataset_level', 0)))
-            self.contributor = dict_.get('contributor')
-            self.project = dict_.get('project')
-
-            self.generate_ids()
+        self.dataset_id = dict_['dataset_id']
+        self.contributor = dict_['contributor']
+        self.project = dict_['project']
 
         backedup_columns = ['instrument_id', 'dataset_id', 'deployment_id']
 
+        self.generate_ids()
+
+        # override generated IDs if loading from a backup
         if set(backedup_columns).issubset(dict_.keys()):
             self.instrument_id = dict_['instrument_id']
             self.dataset_id = dict_['dataset_id']
@@ -414,7 +408,6 @@ class Instrument(base):
 
     def generate_ids(self):
         """Builds and sets class ID field from other attributes"""
-        self.dataset_id = f"{self.dataset_name}_{self.dataset_level}"
 
         if hasattr(self, 'contributor') and hasattr(self, 'project'):
             self.deployment_id = (

--- a/woudc_data_registry/processing.py
+++ b/woudc_data_registry/processing.py
@@ -851,7 +851,7 @@ class Process(object):
         if instrument:
             model = instrument.model
             self.extcsv.extcsv['INSTRUMENT']['Model'] = instrument.model
-        elif not self._add_to_report(332, valueline):
+        elif not self._add_to_report(332, valueline, model=model):
             success = False
 
         return success


### PR DESCRIPTION
- Patch NULL parameter error by reconfiguring Instrument add and build_instrument methods
- Remove redundant variables passed through the Instrument class
- Modify the Instrument add, update, and Deployment add help messages to clarify contributor parameter format
- Change Error codes 331 and 332 to include Instrument name and model, and a suggestion to add the instrument via WDR