### PR TITLE
Test that unclosed quotations do not cause woudc-extcsv to error out

### DIFF
--- a/woudc_data_registry/tests/test_report_generation.py
+++ b/woudc_data_registry/tests/test_report_generation.py
@@ -299,52 +299,43 @@ class OperatorReportTest(SandboxTestSuite):
                 next(reader)
 
     def test_unclosed_quotation_operator_report(self):
-        """ Test that unclosed quotations are reported as errors in the
-        operator report """
+        """ Test that unclosed quotations do not trigger an error,
+        and that the file is processed accordingly """
         filename = 'ecsv-unclosed-double-quotes.csv'
         infile = str(resolve_test_data_path(f'data/general/{filename}'))
         contents = util.read_file(infile)
-        agency = 'HSSRV'
 
         with report.OperatorReport(SANDBOX_DIR) as op_report:
             try:
-                ExtendedCSV(contents, op_report)
-                raise AssertionError(f'Parsing of {infile} did not fail')
-            except NonStandardDataError as err:
-                expected_errors = len(err.args)
-                output_path = os.path.join(SANDBOX_DIR, 'run1')
+                ecsv = ExtendedCSV(contents, op_report)
+                # test that all tables were processed properly
+                ecsv.validate_metadata_tables()
+                ecsv.validate_dataset_tables()
+                data_record = models.DataRecord(ecsv)
+                data_record.filename = filename  # type: ignore[assignment]
 
-                op_report.add_message(254)
-                op_report.write_failing_file(infile, agency)
+                agency = ecsv.extcsv['DATA_GENERATION']['Agency']
 
-                output_path = os.path.join(SANDBOX_DIR,
-                                           'operator-report.csv')
+                op_report.add_message(405)  # File passes validation
+                op_report.write_passing_file(infile, ecsv, data_record)
 
-        self.assertTrue(os.path.exists(output_path))
-        with open(output_path, encoding='utf-8') as output:
-            reader = csv.reader(output)
-            next(reader)
+            except AssertionError as err:
+                raise AssertionError(f'Parsing of {infile} failed: {err}')
 
-            errors = 0
+            output_path = os.path.join(SANDBOX_DIR,
+                                       'operator-report.csv')
 
-            for _ in range(expected_errors):
-                report_line = next(reader)
-                self.assertEqual(report_line[0], 'F')
+            # check operator report
+            self.assertTrue(os.path.exists(output_path))
+            with open(output_path, encoding='utf-8') as output:
+                reader = csv.reader(output)
 
-                if report_line[1] == 'Error':
-                    errors += 1
-
-            self.assertEqual(errors, expected_errors)
-
-            report_line = next(reader)
-            self.assertEqual(report_line[0], 'F')
-            self.assertEqual(report_line[1], 'Error')
-            self.assertEqual(report_line[2], '254')
-            self.assertIn(agency, report_line)
-            self.assertIn(os.path.basename(infile), report_line)
-
-            with self.assertRaises(StopIteration):
-                next(reader)
+                for line in reader:
+                    self.assertEqual(line[0], 'P')
+                    self.assertEqual(line[1], 'Warning')
+                    self.assertEqual(line[2], '405')
+                    self.assertIn(agency, line)
+                    self.assertIn(os.path.basename(infile), line)
 
     def test_mixed_operator_report(self):
         """


### PR DESCRIPTION
- Edit test case for unclosed quotations in CSV